### PR TITLE
Update installer to support opensds project decoupling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DIST_DIR := $(BASE_DIR)/build/dist
 VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
                  git describe --match=$(git rev-parse --short=8 HEAD) \
 		 --always --dirty --abbrev=8)
-BUILD_TGT := opensds-installer-$(VERSION)
+BUILD_TGT := installer-$(VERSION)
 
 all: help
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# opensds-installer
-Installer tool of opensds projects to simplify cluster deployment and configuration.
+# installer
+Installer tool of sodafoundation projects to simplify cluster deployment and configuration.
 
 ## Introduction
 This project is designed for locating the code for installing all required
-components to set up a cluster, including [Hotpot](https://github.com/opensds/opensds),
-[Sushi](https://github.com/opensds/nbp), [Gelato](https://github.com/opensds/multi-cloud),
-[Orchestration](https://github.com/opensds/orchestration) and
-[opensds-dashboard](https://github.com/opensds/opensds-dashboard). Currently we
+components to set up a cluster, including [Hotpot](https://github.com/sodafoundation/opensds),
+[Sushi](https://github.com/sodafoundation/nbp), [Gelato](https://github.com/sodafoundation/multi-cloud),
+[Orchestration](https://github.com/sodafoundation/orchestration) and
+[opensds-dashboard](https://github.com/sodafoundation/opensds-dashboard). Currently we
 support several install tools for diversity.
 
 ### Ansible
@@ -30,4 +30,4 @@ through salt tool.
 ## Contact
 * Mailing list: [opensds-tech-discuss](https://lists.opensds.io/mailman/listinfo/opensds-tech-discuss)
 * slack: #[opensds](https://opensds.slack.com)
-* Ideas/Bugs: [issues](https://github.com/opensds/opensds-installer/issues)
+* Ideas/Bugs: [issues](https://github.com/sodafoundation/installer/issues)

--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -34,8 +34,8 @@ deploy_project: all
 install_from: release
 # These fields below will specify the tag based on install_from type
 repo_branch: master
-release_version: v0.10.0
-image_tag: v0.10.0
+release_version: v0.20.0
+image_tag: v0.20.0
 
 # This field indicates which os family the system will be running, currently
 # support 'Debian' and 'RedHat'

--- a/ansible/group_vars/hotpot.yml
+++ b/ansible/group_vars/hotpot.yml
@@ -57,11 +57,18 @@ dock_remote_url: https://github.com/sodafoundation/dock.git
 ###########
 
 # If user specifies intalling from release,then he can choose the specific version
-hotpot_release: "{{ release_version }}" # The version should be at least v0.20.0
+api_release: "{{ release_version }}" # The version should be at least v0.20.0
+controller_release: "{{ release_version }}" # The version should be at least v0.20.0
+dock_release: "{{ release_version }}" # The version should be at least v0.20.0
 
 # These fields are NOT suggested to be modified
-hotpot_download_url: https://github.com/sodafoundation/releases/releases/download/{{ hotpot_release }}/opensds-hotpot-{{ hotpot_release }}-linux-amd64.tar.gz
-hotpot_tarball_dir: /tmp/opensds-hotpot-{{ hotpot_release }}-linux-amd64
+api_download_url: https://github.com/sodafoundation/api/releases/download/{{ api_release }}/soda-api-{{ api_release }}-linux-amd64.tar.gz
+controller_download_url: https://github.com/sodafoundation/controller/releases/download/{{ controller_release }}/soda-controller-{{ controller_release }}-linux-amd64.tar.gz
+dock_download_url: https://github.com/sodafoundation/dock/releases/download/{{ dock_release }}/soda-dock-{{ dock_release }}-linux-amd64.tar.gz
+
+api_tarball_dir: /tmp/soda-api-{{ api_release }}-linux-amd64
+controller_tarball_dir: /tmp/soda-controller-{{ controller_release }}-linux-amd64
+dock_tarball_dir: /tmp/soda-dock-{{ dock_release }}-linux-amd64
 
 
 #############

--- a/ansible/group_vars/hotpot.yml
+++ b/ansible/group_vars/hotpot.yml
@@ -42,10 +42,14 @@ dock_log_file: "{{ opensds_log_dir }}/osdsdock.log"
 
 # If user specifies intalling from repository, then he can choose the specific
 # repository branch
-hotpot_repo_branch: "{{ repo_branch }}"
+api_repo_branch: "{{ repo_branch }}"
+controller_repo_branch: "{{ repo_branch }}"
+dock_repo_branch: "{{ repo_branch }}"
 
 # These fields are NOT suggested to be modified
-hotpot_remote_url: https://github.com/opensds/opensds.git
+api_remote_url: https://github.com/sodafoundation/api.git
+controller_remote_url: https://github.com/sodafoundation/controller.git
+dock_remote_url: https://github.com/sodafoundation/dock.git
 
 
 ###########

--- a/ansible/group_vars/hotpot.yml
+++ b/ansible/group_vars/hotpot.yml
@@ -57,10 +57,10 @@ dock_remote_url: https://github.com/sodafoundation/dock.git
 ###########
 
 # If user specifies intalling from release,then he can choose the specific version
-hotpot_release: v0.10.1 # The version should be at least v0.2.1
+hotpot_release: "{{ release_version }}" # The version should be at least v0.20.0
 
 # These fields are NOT suggested to be modified
-hotpot_download_url: https://github.com/opensds/opensds/releases/download/{{ hotpot_release }}/opensds-hotpot-{{ hotpot_release }}-linux-amd64.tar.gz
+hotpot_download_url: https://github.com/sodafoundation/releases/releases/download/{{ hotpot_release }}/opensds-hotpot-{{ hotpot_release }}-linux-amd64.tar.gz
 hotpot_tarball_dir: /tmp/opensds-hotpot-{{ hotpot_release }}-linux-amd64
 
 
@@ -68,9 +68,11 @@ hotpot_tarball_dir: /tmp/opensds-hotpot-{{ hotpot_release }}-linux-amd64
 # CONTAINER #
 #############
 
-hotpot_image_tag: v0.10.1
+api_image_tag: "{{ release_version }}"
+controller_image_tag: "{{ release_version }}"
+dock_image_tag: "{{ release_version }}"
 
 # These fields are NOT suggested to be modified
-apiserver_docker_image: opensdsio/opensds-apiserver:{{ hotpot_image_tag }}
-controller_docker_image: opensdsio/opensds-controller:{{ hotpot_image_tag }}
-dock_docker_image: opensdsio/opensds-dock:{{ hotpot_image_tag }}
+apiserver_docker_image: opensdsio/opensds-apiserver:{{ api_image_tag }}
+controller_docker_image: opensdsio/opensds-controller:{{ controller_image_tag }}
+dock_docker_image: opensdsio/opensds-dock:{{ dock_image_tag }}

--- a/ansible/roles/cleaner/scenarios/release.yml
+++ b/ansible/roles/cleaner/scenarios/release.yml
@@ -19,7 +19,9 @@
     state: absent
     force: yes
   with_items:
-    - "{{ hotpot_tarball_dir }}"
+    - "{{ api_tarball_dir }}"
+    - "{{ controller_tarball_dir }}"
+    - "{{ dock_tarball_dir }}"
     - "{{ sushi_tarball_dir }}"
     - "{{ orchestration_tarball_dir }}"
     - "{{ gelato_tarball_dir }}"

--- a/ansible/roles/cleaner/scenarios/repository.yml
+++ b/ansible/roles/cleaner/scenarios/repository.yml
@@ -23,23 +23,37 @@
       - /bin/false
   when: go_path == ""
 
-- name: clean opensds controller data
+- name: clean sodafoundation api data
   shell: make clean
   args:
-    chdir: "{{ go_path }}/src/github.com/opensds/opensds"
+    chdir: "{{ go_path }}/src/github.com/sodafoundation/api"
   when: deploy_project != "gelato"
   tags: hotpot
 
-- name: clean opensds multi-cloud engine data
+- name: clean sodafoundation controller data
   shell: make clean
   args:
-    chdir: "{{ go_path }}/src/github.com/opensds/multi-cloud"
+    chdir: "{{ go_path }}/src/github.com/sodafoundation/controller"
+  when: deploy_project != "gelato"
+  tags: hotpot
+
+- name: clean sodafoundation dock data
+  shell: make clean
+  args:
+    chdir: "{{ go_path }}/src/github.com/sodafoundation/dock"
+  when: deploy_project != "gelato"
+  tags: hotpot
+
+- name: clean sodafoundation multi-cloud engine data
+  shell: make clean
+  args:
+    chdir: "{{ go_path }}/src/github.com/sodafoundation/multi-cloud"
   when: deploy_project != "hotpot"
   tags: gelato
 
-- name: clean opensds northbound plugin data
+- name: clean sodafoundation northbound plugin data
   shell: make clean
   args:
-    chdir: "{{ go_path }}/src/github.com/opensds/nbp"
+    chdir: "{{ go_path }}/src/github.com/sodafoundation/nbp"
   when: sushi_plugin_type != "hotpot_only"
   tags: sushi

--- a/ansible/roles/common/scenarios/release.yml
+++ b/ansible/roles/common/scenarios/release.yml
@@ -13,31 +13,92 @@
 # limitations under the License.
 
 ---
-- name: check for hotpot release files existed
+# api
+- name: check for api release files existed
   stat:
-    path: "{{ hotpot_work_dir }}/bin"
-  register: hotpotreleasesexisted
+    path: "{{ hotpot_work_dir }}/bin/osdsapiserver"
+  register: apireleasesexisted
 
-- name: download and extract the hotpot release tarball if not exists
+- name: download and extract the api release tarball if not exists
   unarchive:
-    src: "{{ hotpot_download_url }}"
+    src: "{{ api_download_url }}"
     dest: /tmp/
     remote_src: yes
   when:
-    - hotpotreleasesexisted.stat.exists is undefined or hotpotreleasesexisted.stat.exists == false
+    - apireleasesexisted.stat.exists is undefined or apireleasesexisted.stat.exists == false
 
-- name: change the mode of all binary files in hotpot release
+- name: change the mode of all binary files in api release
   file:
-    path: "{{ hotpot_tarball_dir }}/bin"
+    path: "{{ api_tarball_dir }}/bin"
     mode: 0755
     recurse: yes
   when:
-    - hotpotreleasesexisted.stat.exists is undefined or hotpotreleasesexisted.stat.exists == false
+    - apireleasesexisted.stat.exists is undefined or apireleasesexisted.stat.exists == false
 
-- name: copy hotpot tarball into hotpot work directory
+- name: copy api tarball into hotpot work directory
   copy:
-    src: "{{ hotpot_tarball_dir }}/"
+    src: "{{ api_tarball_dir }}/"
     dest: "{{ hotpot_work_dir }}"
     mode: 0755
   when:
-    - hotpotreleasesexisted.stat.exists is undefined or hotpotreleasesexisted.stat.exists == false
+    - apireleasesexisted.stat.exists is undefined or apireleasesexisted.stat.exists == false
+
+# controller
+- name: check for controller release files existed
+  stat:
+    path: "{{ hotpot_work_dir }}/bin/osdslet"
+  register: controllerreleasesexisted
+
+- name: download and extract the controller release tarball if not exists
+  unarchive:
+    src: "{{ controller_download_url }}"
+    dest: /tmp/
+    remote_src: yes
+  when:
+    - controllerreleasesexisted.stat.exists is undefined or controllerreleasesexisted.stat.exists == false
+
+- name: change the mode of all binary files in controller release
+  file:
+    path: "{{ controller_tarball_dir }}/bin"
+    mode: 0755
+    recurse: yes
+  when:
+    - controllerreleasesexisted.stat.exists is undefined or controllerreleasesexisted.stat.exists == false
+
+- name: copy controller tarball into hotpot work directory
+  copy:
+    src: "{{ controller_tarball_dir }}/"
+    dest: "{{ hotpot_work_dir }}"
+    mode: 0755
+  when:
+    - controllerreleasesexisted.stat.exists is undefined or controllerreleasesexisted.stat.exists == false
+
+# dock
+- name: check for dock release files existed
+  stat:
+    path: "{{ hotpot_work_dir }}/bin/osdsdock"
+  register: dockreleasesexisted
+
+- name: download and extract the dock release tarball if not exists
+  unarchive:
+    src: "{{ dock_download_url }}"
+    dest: /tmp/
+    remote_src: yes
+  when:
+    - dockreleasesexisted.stat.exists is undefined or dockreleasesexisted.stat.exists == false
+
+- name: change the mode of all binary files in dock release
+  file:
+    path: "{{ dock_tarball_dir }}/bin"
+    mode: 0755
+    recurse: yes
+  when:
+    - dockreleasesexisted.stat.exists is undefined or dockreleasesexisted.stat.exists == false
+
+- name: copy dock tarball into hotpot work directory
+  copy:
+    src: "{{ dock_tarball_dir }}/"
+    dest: "{{ hotpot_work_dir }}"
+    mode: 0755
+  when:
+    - dockreleasesexisted.stat.exists is undefined or dockreleasesexisted.stat.exists == false

--- a/ansible/roles/common/scenarios/repository.yml
+++ b/ansible/roles/common/scenarios/repository.yml
@@ -23,32 +23,78 @@
     - /bin/false
   when: go_path == ""
 
-- name: check for hotpot source code existed
+# Build api
+- name: check for api source code existed
   stat:
-    path: "{{ go_path }}/src/github.com/opensds/opensds"
-  register: hotpotexisted
+    path: "{{ go_path }}/src/github.com/sodafoundation/api"
+  register: apiexisted
 
-- name: download hotpot source code if not exists
+- name: download api source code if not exists
   git:
-    repo: "{{ hotpot_remote_url }}"
-    dest: "{{ go_path }}/src/github.com/opensds/opensds"
-    version: "{{ hotpot_repo_branch }}"
-  when: hotpotexisted.stat.exists is undefined or hotpotexisted.stat.exists == false
+    repo: "{{ api_remote_url }}"
+    dest: "{{ go_path }}/src/github.com/sodafoundation/api"
+    version: "{{ api_repo_branch }}"
+  when: apiexisted.stat.exists is undefined or apiexisted.stat.exists == false
 
-- name: build hotpot binary file
+- name: build api binary file
   shell: make
   environment:
     GOPATH: "{{ go_path }}"
   args:
-    chdir: "{{ go_path }}/src/github.com/opensds/opensds"
+    chdir: "{{ go_path }}/src/github.com/sodafoundation/api"
+
+
+# Build controller
+- name: check for controller source code existed
+  stat:
+    path: "{{ go_path }}/src/github.com/sodafoundation/controller"
+  register: controllerexisted
+
+- name: download controller source code if not exists
+  git:
+    repo: "{{ controller_remote_url }}"
+    dest: "{{ go_path }}/src/github.com/sodafoundation/controller"
+    version: "{{ controller_repo_branch }}"
+  when: controllerexisted.stat.exists is undefined or controllerexisted.stat.exists == false
+
+- name: build controller binary file
+  shell: make
+  environment:
+    GOPATH: "{{ go_path }}"
+  args:
+    chdir: "{{ go_path }}/src/github.com/sodafoundation/controller"
+
+
+# Build dock
+- name: check for dock source code existed
+  stat:
+    path: "{{ go_path }}/src/github.com/sodafoundation/dock"
+  register: dockexisted
+
+- name: download dock source code if not exists
+  git:
+    repo: "{{ dock_remote_url }}"
+    dest: "{{ go_path }}/src/github.com/sodafoundation/dock"
+    version: "{{ dock_repo_branch }}"
+  when: dockexisted.stat.exists is undefined or dockexisted.stat.exists == false
+
+- name: build dock binary file
+  shell: make
+  environment:
+    GOPATH: "{{ go_path }}"
+  args:
+    chdir: "{{ go_path }}/src/github.com/sodafoundation/dock"
+
 
 - name: copy hotpot binary and openapi files into hotpot work directory
   copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   with_items:
-    - { src: "{{ go_path }}/src/github.com/opensds/opensds/build/out/", dest: "{{ hotpot_work_dir }}" }
-    - { src: "{{ go_path }}/src/github.com/opensds/opensds/openapi-spec/", dest: "{{ hotpot_work_dir }}" }
+    - { src: "{{ go_path }}/src/github.com/sodafoundation/api/build/out/", dest: "{{ hotpot_work_dir }}" }
+    - { src: "{{ go_path }}/src/github.com/sodafoundation/controller/build/out/", dest: "{{ hotpot_work_dir }}" }
+    - { src: "{{ go_path }}/src/github.com/sodafoundation/dock/build/out/", dest: "{{ hotpot_work_dir }}" }
+    - { src: "{{ go_path }}/src/github.com/sodafoundation/api/openapi-spec/", dest: "{{ hotpot_work_dir }}" }
 
 - name: change the permissions of hotpot executable files
   file:

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -51,7 +51,7 @@
   with_items:
     - librados-dev
     - librbd-dev
-  when: ansible_os_family == "Debian" and deploy_project != "gelato"
+  when: ansible_os_family == "Debian"
 
 - name: create opensds work directory if it doesn't exist
   file:

--- a/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
+++ b/ansible/roles/telemetry-installer/scenarios/install_telemetry_tools.yml
@@ -238,7 +238,7 @@
   tags:
     - lvm_exporter
   with_items:
-    - cp /opt/opensds-hotpot-linux-amd64/bin/lvm_exporter /usr/local/bin/
+    - cp {{ hotpot_work_dir }}/bin/lvm_exporter /usr/local/bin/
     - chown root:root /usr/local/bin/lvm_exporter
   become: yes
 

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -141,6 +141,7 @@
   remote_user: root
   vars_files:
     - group_vars/common.yml
+    - group_vars/hotpot.yml
     - group_vars/telemetry.yml
   gather_facts: false
   become: True

--- a/charts/OpenSDS Installation using Helm.md
+++ b/charts/OpenSDS Installation using Helm.md
@@ -290,9 +290,9 @@ helm install csiplugin-file/ --name={ csiplugin_service_name }
 ### OpenSDS CLI tool
 #### Download cli tool
 ```
-wget https://github.com/opensds/opensds/releases/download/v0.10.0/opensds-hotpot-v0.10.0-linux-amd64.tar.gz
-tar zxvf opensds-hotpot-v0.10.0-linux-amd64.tar.gz
-cp opensds-hotpot-v0.10.0-linux-amd64/bin/* /usr/local/bin
+wget https://github.com/opensds/opensds/releases/download/v0.20.0/opensds-hotpot-v0.20.0-linux-amd64.tar.gz
+tar zxvf opensds-hotpot-v0.20.0-linux-amd64.tar.gz
+cp opensds-hotpot-v0.20.0-linux-amd64/bin/* /usr/local/bin
 chmod 755 /usr/local/bin/osdsctl
 
 export OPENSDS_ENDPOINT=http://{{ apiserver_cluster_ip }}:50040
@@ -334,8 +334,8 @@ Logout of the dashboard as admin and login the dashboard again as a non-admin us
 
 #### For CSI Plugin
 ```
-wget https://github.com/opensds/nbp/releases/download/v0.10.0/opensds-sushi-v0.10.0-linux-amd64.tar.gz
-tar zxvf opensds-sushi-v0.10.0-linux-amd64.tar.gz
+wget https://github.com/sodafoundation/nbp/releases/download/v0.20.0/opensds-sushi-v0.20.0-linux-amd64.tar.gz
+tar zxvf opensds-sushi-v0.20.0-linux-amd64.tar.gz
 cd /opensds-sushi-linux-amd64
 ```
 

--- a/charts/csiplugin-block/values.yaml
+++ b/charts/csiplugin-block/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image: opensdsio/csiplugin-block:v0.10.0
+image: opensdsio/csiplugin-block:v0.20.0
 # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 # ImageRestartPolicy: valid values are "Never", and "Always"

--- a/charts/csiplugin-file/values.yaml
+++ b/charts/csiplugin-file/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-image: opensdsio/csiplugin-file:v0.10.0
+image: opensdsio/csiplugin-file:v0.20.0
 # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent
 # ImageRestartPolicy: valid values are "Never", and "Always"

--- a/charts/opensds/values.yaml
+++ b/charts/opensds/values.yaml
@@ -13,7 +13,7 @@ deployments:
 osdsapiserver:
   name: apiserver
   replicaCount: 1
-  image: opensdsio/opensds-apiserver:v0.10.0
+  image: opensdsio/opensds-apiserver:v0.20.0
   # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
   imagePullPolicy: IfNotPresent
   # Attributes of the apiserver's service resource
@@ -40,7 +40,7 @@ osdsapiserver:
 osdslet:
   name: controller
   replicaCount: 1
-  image: opensdsio/opensds-controller:v0.10.0
+  image: opensdsio/opensds-controller:v0.20.0
   # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
   imagePullPolicy: IfNotPresent
   # Attributes of the controller's service resource
@@ -67,7 +67,7 @@ osdslet:
 osdsdock:
   name: dock
   replicaCount: 1
-  image: opensdsio/opensds-dock:v0.10.0
+  image: opensdsio/opensds-dock:v0.20.0
   # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
   imagePullPolicy: IfNotPresent
   # Attributes of the dock's service resource
@@ -94,7 +94,7 @@ osdsdock:
 osdsdashboard:
   name: dashboard
   replicaCount: 1
-  image: opensdsio/dashboard:v0.10.0
+  image: opensdsio/dashboard:v0.20.0
   # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
   imagePullPolicy: IfNotPresent
   # Attributes of the dashboard's service resource

--- a/charts/servicebroker/values.yaml
+++ b/charts/servicebroker/values.yaml
@@ -2,7 +2,7 @@
 # Image to use
 name: servicebroker
 image:
-  service-broker: opensdsio/service-broker:v0.10.0
+  service-broker: opensdsio/service-broker:v0.20.0
   etcd-store: quay.io/coreos/etcd:latest
 # ImagePullPolicy; valid values are "IfNotPresent", "Never", and "Always"
 imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Update the installer to support opensds project decoupling to api, controller and dock
(Earlier github.com/opensds/opensds has been migrated to github.com/sodafoundation/opensds and this project/repo has been decoupled to github.com/sodafoundation/api , github.com/sodafoundation/controller and github.com/sodafoundation/dock)