### PR TITLE
Allow unauth packages for rabbitmq install

### DIFF
--- a/ansible/roles/sim-installer/scenarios/rabbitmq.yml
+++ b/ansible/roles/sim-installer/scenarios/rabbitmq.yml
@@ -58,8 +58,9 @@
 - name: Install RabbitMQ package
   apt: 
     name: "{{ item }}"
-    update_cache: no
+    update_cache: yes
     install_recommends: yes
+    allow_unauthenticated: yes
     state: present
   with_items:
     - apt-transport-https 


### PR DESCRIPTION

Allow unauth packages for rabbitmq install

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

 /kind bug fix


**What this PR does / why we need it**:
This PR allows rabbitmq package to install unauthorized dependant packages

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #358 

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED
> /kind NOT-TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
