### PR TITLE
Update Deployment APIVersion to apps/v1

### DIFF
--- a/charts/opensds/templates/deployment.yaml
+++ b/charts/opensds/templates/deployment.yaml
@@ -16,7 +16,7 @@
 # Apiserver deployment
 ##########################################################################
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "osdsapiserver.fullname" . }}
   labels:
@@ -58,7 +58,7 @@ spec:
 # Controller deployment
 ##########################################################################
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "osdslet.fullname" . }}
   labels:
@@ -100,7 +100,7 @@ spec:
 # Dock deployment
 ##########################################################################
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "osdsdock.fullname" . }}
   labels:
@@ -188,7 +188,7 @@ spec:
 # DB deployment
 ##########################################################################
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "osdsdb.fullname" . }}
   labels:
@@ -238,7 +238,7 @@ spec:
 {{- if .Values.deployments.osdsdashboard }}
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "osdsdashboard.fullname" . }}
   labels:
@@ -281,7 +281,7 @@ spec:
 {{- if .Values.deployments.osdsauthchecker }}
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "osdsauthchecker.fullname" . }}
   labels:


### PR DESCRIPTION
/kind enhancement
Continued deprecation of extensions/v1beta1, apps/v1beta1, and apps/v1beta2 APIs; these extensions will be retired in 1.16!
So when we using helm to deploy in k8s 1.16, there will be one error like this:
```
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1"
```