### PR TITLE
[WIP] Devsds installation script fix - for hard coded paths

### DIFF
--- a/devsds/lib/opensds.sh
+++ b/devsds/lib/opensds.sh
@@ -23,8 +23,8 @@ set +o xtrace
 soda:opensds:configuration(){
 
 # Copy api spec file to configuration path
-SODA_API_DIR=${SODA_DIR}/../../api
-cp $SODA_API_DIR/openapi-spec/swagger.yaml $SODA_CONFIG_DIR
+SODA_API_DIR=/opt/opensds-hotpot-linux-amd64
+cp $SODA_API_DIR/swagger.yaml $SODA_CONFIG_DIR
 
 # Set global configuration.
 cat >> $SODA_CONFIG_DIR/opensds.conf << OPENSDS_GLOBAL_CONFIG_DOC
@@ -58,10 +58,9 @@ soda::opensds::install(){
 # Run osdsdock and osdslet daemon in background.
 (
     cd ${SODA_API_DIR}
-    sudo build/out/bin/osdsapiserver --daemon
-    cd ..
-    sudo controller/build/out/bin/osdslet --daemon
-    sudo dock/build/out/bin/osdsdock --daemon
+    sudo bin/osdsapiserver --daemon
+    sudo bin/osdslet --daemon
+    sudo bin/osdsdock --daemon
 
     soda::echo_summary "Waiting for osdsapiserver to come up."
     soda::util::wait_for_url localhost:50040 "osdsapiserver" 0.5 80
@@ -83,14 +82,14 @@ soda::opensds::install(){
             $xtrace
         fi
     fi
-
+    
     # Copy bash completion script to system.
-    cp ${SODA_API_DIR}/osdsctl/completion/osdsctl.bash_completion /etc/bash_completion.d/
+    cp osdsctl.bash_completion /etc/bash_completion.d/
 
     export OPENSDS_AUTH_STRATEGY=$SODA_AUTH_STRATEGY
     export OPENSDS_ENDPOINT=http://localhost:50040
-    ${SODA_API_DIR}/build/out/bin/osdsctl profile create '{"name": "default_block", "description": "default policy", "storageType": "block"}'
-    ${SODA_API_DIR}/build/out/bin/osdsctl profile create '{"name": "default_file", "description": "default policy", "storageType": "file", "provisioningProperties":{"ioConnectivity": {"accessProtocol": "NFS"},"DataStorage":{"StorageAccessCapability":["Read","Write","Execute"]}}}'
+    ${SODA_API_DIR}/bin/osdsctl profile create '{"name": "default_block", "description": "default policy", "storageType": "block"}'
+    ${SODA_API_DIR}/bin/osdsctl profile create '{"name": "default_file", "description": "default policy", "storageType": "file", "provisioningProperties":{"ioConnectivity": {"accessProtocol": "NFS"},"DataStorage":{"StorageAccessCapability":["Read","Write","Execute"]}}}'
 
     if [ $? == 0 ]; then
         soda::echo_summary devsds installed successfully !! 

--- a/devsds/osdsctl.bash_completion
+++ b/devsds/osdsctl.bash_completion
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_osdsctl() {
+    COMPREPLY=()
+    local cur=${COMP_WORDS[COMP_CWORD]};
+    local pre=${COMP_WORDS[COMP_CWORD-1]};
+    case "$COMP_CWORD $pre" in
+    "1 osdsctl")
+          COMPREPLY=($(compgen -W 'dock pool profile version volume fileshare host' -- $cur)) ;;
+    "2 dock")
+          COMPREPLY=($(compgen -W 'list show' -- $cur)) ;;
+    "2 pool")
+          COMPREPLY=($(compgen -W 'list show' -- $cur)) ;;
+    "2 profile")
+          COMPREPLY=($(compgen -W 'create delete list show' -- $cur)) ;;
+    "2 version")
+          COMPREPLY=($(compgen -W 'list show' -- $cur)) ;;
+    "2 volume")
+          COMPREPLY=($(compgen -W 'attachment create delete list show extend snapshot update group replication' -- $cur)) ;;
+    "2 fileshare")
+          COMPREPLY=($(compgen -W 'create delete list show acl snapshot' -- $cur)) ;;
+    "2 host")
+          COMPREPLY=($(compgen -W 'create delete list show update initiator' -- $cur)) ;;
+    '*')
+          ;;
+    esac
+
+    # differentiate volume and fileshare
+    if [[ $COMP_CWORD == 3 ]]; then
+        local ppre=${COMP_WORDS[COMP_CWORD-2]};
+        case "$ppre $pre" in
+        "volume replication")
+          COMPREPLY=($(compgen -W 'create delete list show update enable disable failover' -- $cur)) ;;
+        "volume snapshot" | "fileshare snapshot")
+              COMPREPLY=($(compgen -W 'create delete list show update' -- $cur)) ;;
+        "volume attachment")
+              COMPREPLY=($(compgen -W 'create delete list show update' -- $cur)) ;;
+        "volume group")
+            COMPREPLY=($(compgen -W 'create delete list show update' -- $cur)) ;;
+        "fileshare acl")
+              COMPREPLY=($(compgen -W 'create delete list show' -- $cur)) ;;
+        "host initiator")
+              COMPREPLY=($(compgen -W 'add remove' -- $cur)) ;;
+    esac
+    fi
+    return 0
+}
+complete -o bashdefault -o default -F _osdsctl osdsctl


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
SODA_API_PATH has been hard coded so installation was failing by throwing no such file/directory
For detail description issue has been raised #382 

**What type of PR is this?**
Bug #382 
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind new feature
> /kind bug fix
#382 
> /kind cleanup
> /kind revert change
> /kind design
> /kind documentation
> /kind enhancement

**What this PR does / why we need it**:
To install using devsds scripts

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #382 

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED
> /kind NOT-TESTED
TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
```
root@root1-HP-EliteBook-840-G2:~/installer/devsds# ./install.sh 
Starting install...
+ set -o errexit
+++ dirname ./install.sh
++ cd .
++ pwd
+ TOP_DIR=/root/installer/devsds
+ echo 'TOP DIR /root/installer/devsds'
TOP DIR /root/installer/devsds
++ cd /root/installer/devsds/
++ pwd
+ SODA_DIR=/root/installer/devsds
+ SODA_CONFIG_DIR=/etc/opensds
+ SODA_DRIVER_CONFIG_DIR=/etc/opensds/driver
+ export OPENSSL_CONF=/root/installer/devsds/lib/openssl.cnf
+ OPENSSL_CONF=/root/installer/devsds/lib/openssl.cnf
+ mkdir -p /etc/opensds/driver
+ OPT_DIR=/opt/sodafoundation
+ OPT_BIN=/opt/sodafoundation/bin
+ mkdir -p /opt/sodafoundation/bin
+ export PATH=/opt/sodafoundation/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/go/bin:/usr/local/go/bin:/usr/local/go/bin
+ PATH=/opt/sodafoundation/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/go/bin:/usr/local/go/bin:/usr/local/go/bin
+ LOGFILE=/var/log/sodafoundation/devsds.log
+ TIMESTAMP_FORMAT=%F-%H%M%S
+ LOGDAYS=7
++ date +%F-%H%M%S
+ CURRENT_LOG_TIME=2020-08-18-184925
+ LOGFILE_DIR=/var/log/sodafoundation
+ LOGFILE_NAME=devsds.log
+ mkdir -p /var/log/sodafoundation
+ find /var/log/sodafoundation -maxdepth 1 -name 'devsds.log.*' -mtime +7 -exec rm '{}' ';'
+ LOGFILE=/var/log/sodafoundation/devsds.log.2020-08-18-184925
+ SUMFILE=/var/log/sodafoundation/devsds.log.2020-08-18-184925.summary.2020-08-18-184925
++ which python
+ [[ -z /usr/bin/python ]]
+ exec
+ exec
++ /root/installer/devsds/tools/outfilter.py -v -o /var/log/sodafoundation/devsds.log.2020-08-18-184925
2020-08-18 13:19:25.280 | + exec
2020-08-18 13:19:25.280 | + soda::echo_summary 'install.sh log /var/log/sodafoundation/devsds.log.2020-08-18-184925'
2020-08-18 13:19:25.280 | + echo -e install.sh log /var/log/sodafoundation/devsds.log.2020-08-18-184925
2020-08-18 13:19:25.280 | + ln -sf /var/log/sodafoundation/devsds.log.2020-08-18-184925 /var/log/sodafoundation/devsds.log
2020-08-18 13:19:25.280 | + ln -sf /var/log/sodafoundation/devsds.log.2020-08-18-184925.summary.2020-08-18-184925 /var/log/sodafoundation/devsds.log.summary
2020-08-18 13:19:25.280 | ++ /root/installer/devsds/tools/outfilter.py -o /var/log/sodafoundation/devsds.log.2020-08-18-184925.summary.2020-08-18-184925
2020-08-18 13:19:25.280 | + source /root/installer/devsds/lib/util.sh
2020-08-18 13:19:25.281 | + source /root/installer/devsds/sdsrc
2020-08-18 13:19:25.281 | ++ source /root/installer/devsds/local.conf
2020-08-18 13:19:25.282 | +++ SODA_BACKEND_LIST=lvm,nfs
2020-08-18 13:19:25.283 | +++ SODA_AUTH_STRATEGY=keystone
2020-08-18 13:19:25.283 | +++ SODA_PROJECT=api,controller,dock
2020-08-18 13:19:25.283 | +++ USE_EXISTING_KEYSTONE=false
2020-08-18 13:19:25.283 | +++ USE_CONTAINER_KEYSTONE=true
2020-08-18 13:19:25.283 | ++ source /root/installer/devsds/lib/util.sh
2020-08-18 13:19:25.283 | ++ HOST_IP=
2020-08-18 13:19:25.283 | +++ soda::util::get_default_host_ip '' inet
2020-08-18 13:19:25.283 | +++ local host_ip=
2020-08-18 13:19:25.283 | +++ local af=inet
2020-08-18 13:19:25.283 | +++ '[' -z '' ']'
2020-08-18 13:19:25.283 | +++ host_ip=
2020-08-18 13:19:25.283 | ++++ ip -f inet route
2020-08-18 13:19:25.283 | ++++ awk '/default/ {print $5}'
2020-08-18 13:19:25.283 | ++++ head -1
2020-08-18 13:19:25.283 | +++ host_ip_iface=wlo1
2020-08-18 13:19:25.283 | +++ local host_ips
2020-08-18 13:19:25.283 | ++++ awk '/inet/ {split($2,parts,"/");  print parts[1]}'
2020-08-18 13:19:25.283 | ++++ sed /temporary/d
2020-08-18 13:19:25.283 | ++++ LC_ALL=C
2020-08-18 13:19:25.283 | ++++ ip -f inet addr show wlo1
2020-08-18 13:19:25.283 | +++ host_ips=192.168.1.101
2020-08-18 13:19:25.283 | +++ local ip
2020-08-18 13:19:25.283 | +++ for ip in '$host_ips'
2020-08-18 13:19:25.283 | +++ host_ip=192.168.1.101
2020-08-18 13:19:25.283 | +++ break
2020-08-18 13:19:25.283 | +++ echo 192.168.1.101
2020-08-18 13:19:25.283 | ++ HOST_IP=192.168.1.101
2020-08-18 13:19:25.283 | ++ '[' 192.168.1.101 == '' ']'
2020-08-18 13:19:25.283 | ++ SODA_VERSION=v1beta
2020-08-18 13:19:25.283 | ++ SODA_AUTH_STRATEGY=keystone
2020-08-18 13:19:25.283 | ++ SODA_SERVER_NAME=opensds
2020-08-18 13:19:25.283 | ++ SODA_BACKEND_LIST=lvm,nfs
2020-08-18 13:19:25.283 | ++ SODA_PROJECT=api,controller,dock
2020-08-18 13:19:25.283 | ++ STACK_GIT_BASE=https://git.openstack.org
2020-08-18 13:19:25.284 | ++ STACK_USER_NAME=stack
2020-08-18 13:19:25.284 | ++ STACK_PASSWORD=opensds@123
2020-08-18 13:19:25.284 | ++ STACK_HOME=/opt/stack
2020-08-18 13:19:25.284 | ++ STACK_BRANCH=stable/queens
2020-08-18 13:19:25.284 | ++ DEV_STACK_DIR=/opt/stack/devstack
2020-08-18 13:19:25.284 | ++ ETCD_VERSION=3.3.10
2020-08-18 13:19:25.284 | ++ ETCD_HOST=192.168.1.101
2020-08-18 13:19:25.284 | ++ ETCD_PORT=62379
2020-08-18 13:19:25.284 | ++ ETCD_PEER_PORT=62380
2020-08-18 13:19:25.284 | ++ ETCD_DIR=/opt/sodafoundation/etcd
2020-08-18 13:19:25.284 | ++ ETCD_LOGFILE=/opt/sodafoundation/etcd/etcd.log
2020-08-18 13:19:25.284 | ++ ETCD_DATADIR=/opt/sodafoundation/etcd/data
2020-08-18 13:19:25.284 | ++ SODA_ENABLED_SERVICES=opensds,etcd,certificate
2020-08-18 13:19:25.284 | ++ '[' keystone = keystone ']'
2020-08-18 13:19:25.284 | ++ SODA_ENABLED_SERVICES+=,keystone
2020-08-18 13:19:25.284 | ++ SODA_ENABLED_SERVICES+=,lvm,nfs
2020-08-18 13:19:25.284 | ++ SUPPORT_SERVICES=certificate,keystone,lvm,ceph,etcd,opensds
2020-08-18 13:19:25.284 | + soda::backendlist_check lvm,nfs
2020-08-18 13:19:25.284 | + local backendlist=lvm,nfs
2020-08-18 13:19:25.284 | ++ tr , ' '
2020-08-18 13:19:25.284 | ++ echo lvm,nfs
2020-08-18 13:19:25.284 | + for backend in '$(echo $backendlist | tr "," " ")'
2020-08-18 13:19:25.284 | + case $backend in
2020-08-18 13:19:25.284 | + for backend in '$(echo $backendlist | tr "," " ")'
2020-08-18 13:19:25.284 | + case $backend in
2020-08-18 13:19:25.284 | + echo 'Backedn lvm,nfs'
2020-08-18 13:19:25.284 | Backedn lvm,nfs
2020-08-18 13:19:25.284 | + :
2020-08-18 13:19:25.284 | + soda::util::service_operation install
2020-08-18 13:19:25.284 | + local action=install
2020-08-18 13:19:25.284 | ++ tr , ' '
2020-08-18 13:19:25.284 | ++ echo certificate,keystone,lvm,ceph,etcd,opensds
2020-08-18 13:19:25.284 | + for service in '$(echo $SUPPORT_SERVICES|tr '\'','\'' '\'' '\'')'
2020-08-18 13:19:25.284 | + soda::util::is_service_enabled certificate
2020-08-18 13:19:25.284 | + local enabled=1
2020-08-18 13:19:25.284 | + local services=certificate
2020-08-18 13:19:25.284 | + local service
2020-08-18 13:19:25.284 | + for service in '${services}'
2020-08-18 13:19:25.284 | + [[ ,opensds,etcd,certificate,keystone,lvm,nfs, =~ ,certificate, ]]
2020-08-18 13:19:25.284 | + enabled=0
2020-08-18 13:19:25.284 | + return 0
2020-08-18 13:19:25.284 | + source /root/installer/devsds/lib/certificate.sh
2020-08-18 13:19:25.286 | + soda::certificate::install
2020-08-18 13:19:25.286 | + soda::certificate::cleanup
2020-08-18 13:19:25.286 | + soda::certificate::uninstall
2020-08-18 13:19:25.286 | + '[' -d /opt/soda-security ']'
2020-08-18 13:19:25.286 | + soda::certificate::check_openssl_installed
2020-08-18 13:19:25.286 | + openssl version
2020-08-18 13:19:25.288 | + '[' 0 -ne 0 ']'
2020-08-18 13:19:25.288 | + soda::certificate::prepare
2020-08-18 13:19:25.289 | + mkdir -p /opt/soda-security/ca
2020-08-18 13:19:25.289 | + mkdir -p /opt/soda-security/ca/demoCA/
2020-08-18 13:19:25.290 | + mkdir -p /opt/soda-security/ca/demoCA/newcerts
2020-08-18 13:19:25.291 | + touch /opt/soda-security/ca/demoCA/index.txt
2020-08-18 13:19:25.291 | + echo 01
2020-08-18 13:19:25.291 | + echo 'unique_subject = no'
2020-08-18 13:19:25.291 | + soda::certificate::create_ca_cert
2020-08-18 13:19:25.291 | + cd /opt/soda-security/ca
2020-08-18 13:19:25.291 | + openssl genrsa -passout pass:xxxxx -out /opt/soda-security/ca/ca-key.pem -aes256 2048
2020-08-18 13:19:25.293 | Generating RSA private key, 2048 bit long modulus
2020-08-18 13:19:25.441 | ..................................................................................................................................+++
2020-08-18 13:19:25.455 | ............+++
2020-08-18 13:19:25.456 | e is 65537 (0x10001)
2020-08-18 13:19:25.456 | + openssl req -new -x509 -sha256 -key /opt/soda-security/ca/ca-key.pem -out /opt/soda-security/ca/ca-cert.pem -days 365 -subj /CN=CA -passin pass:xxxxx
2020-08-18 13:19:25.460 | + soda::certificate::create_component_cert
2020-08-18 13:19:25.460 | + for com in '${COMPONENT[*]}'
2020-08-18 13:19:25.460 | + openssl genrsa -aes256 -passout pass:xxxxx -out /opt/soda-security/ca/opensds-key.pem 2048
2020-08-18 13:19:25.462 | Generating RSA private key, 2048 bit long modulus
2020-08-18 13:19:25.517 | .................................................+++
2020-08-18 13:19:25.529 | ..........+++
2020-08-18 13:19:25.530 | e is 65537 (0x10001)
2020-08-18 13:19:25.530 | + openssl req -new -sha256 -key /opt/soda-security/ca/opensds-key.pem -out /opt/soda-security/ca/opensds-csr.pem -days 365 -subj /CN=opensds -passin pass:xxxxx
2020-08-18 13:19:25.534 | + openssl ca -batch -in /opt/soda-security/ca/opensds-csr.pem -cert /opt/soda-security/ca/ca-cert.pem -keyfile /opt/soda-security/ca/ca-key.pem -out /opt/soda-security/ca/opensds-cert.pem -md sha256 -days 365 -passin pass:xxxxx
2020-08-18 13:19:25.536 | Using configuration from /root/installer/devsds/lib/openssl.cnf
2020-08-18 13:19:25.536 | Check that the request matches the signature
2020-08-18 13:19:25.537 | Signature ok
2020-08-18 13:19:25.537 | Certificate Details:
2020-08-18 13:19:25.537 |         Serial Number: 1 (0x1)
2020-08-18 13:19:25.537 |         Validity
2020-08-18 13:19:25.537 |             Not Before: Aug 18 13:19:25 2020 GMT
2020-08-18 13:19:25.537 |             Not After : Aug 18 13:19:25 2021 GMT
2020-08-18 13:19:25.537 |         Subject:
2020-08-18 13:19:25.537 |             commonName                = opensds
2020-08-18 13:19:25.537 |         X509v3 extensions:
2020-08-18 13:19:25.537 |             X509v3 Basic Constraints: 
2020-08-18 13:19:25.537 |                 CA:FALSE
2020-08-18 13:19:25.537 |             Netscape Comment: 
2020-08-18 13:19:25.537 |                 OpenSSL Generated Certificate
2020-08-18 13:19:25.537 |             X509v3 Subject Key Identifier: 
2020-08-18 13:19:25.537 |                 69:0E:73:3E:98:FB:E9:BF:80:36:4B:8E:41:7F:FF:3B:E9:81:B0:CF
2020-08-18 13:19:25.537 |             X509v3 Authority Key Identifier: 
2020-08-18 13:19:25.537 |                 keyid:29:45:57:BB:1E:7B:C8:29:AB:AE:1D:06:EB:0C:E7:49:85:2A:D2:67
2020-08-18 13:19:25.538 | 
2020-08-18 13:19:25.538 | Certificate is to be certified until Aug 18 13:19:25 2021 GMT (365 days)
2020-08-18 13:19:25.538 | 
2020-08-18 13:19:25.538 | Write out database with 1 new entries
2020-08-18 13:19:25.539 | Data Base Updated
2020-08-18 13:19:25.539 | + openssl rsa -in /opt/soda-security/ca/opensds-key.pem -out /opt/soda-security/ca/opensds-key.pem -passin pass:xxxxx
2020-08-18 13:19:25.541 | writing RSA key
2020-08-18 13:19:25.542 | + mkdir -p /opt/soda-security/opensds
2020-08-18 13:19:25.542 | + mv /opt/soda-security/ca/opensds-key.pem /opt/soda-security/opensds/
2020-08-18 13:19:25.543 | + mv /opt/soda-security/ca/opensds-cert.pem /opt/soda-security/opensds/
2020-08-18 13:19:25.545 | + rm -rf /opt/soda-security/ca/opensds-csr.pem
2020-08-18 13:19:25.546 | + for com in '${COMPONENT[*]}'
2020-08-18 13:19:25.546 | + openssl genrsa -aes256 -passout pass:xxxxx -out /opt/soda-security/ca/nbp-key.pem 2048
2020-08-18 13:19:25.548 | Generating RSA private key, 2048 bit long modulus
2020-08-18 13:19:25.559 | .........+++
2020-08-18 13:19:25.570 | .........+++
2020-08-18 13:19:25.570 | e is 65537 (0x10001)
2020-08-18 13:19:25.571 | + openssl req -new -sha256 -key /opt/soda-security/ca/nbp-key.pem -out /opt/soda-security/ca/nbp-csr.pem -days 365 -subj /CN=nbp -passin pass:xxxxx
2020-08-18 13:19:25.574 | + openssl ca -batch -in /opt/soda-security/ca/nbp-csr.pem -cert /opt/soda-security/ca/ca-cert.pem -keyfile /opt/soda-security/ca/ca-key.pem -out /opt/soda-security/ca/nbp-cert.pem -md sha256 -days 365 -passin pass:xxxxx
2020-08-18 13:19:25.576 | Using configuration from /root/installer/devsds/lib/openssl.cnf
2020-08-18 13:19:25.577 | Check that the request matches the signature
2020-08-18 13:19:25.577 | Signature ok
2020-08-18 13:19:25.577 | Certificate Details:
2020-08-18 13:19:25.577 |         Serial Number: 2 (0x2)
2020-08-18 13:19:25.577 |         Validity
2020-08-18 13:19:25.577 |             Not Before: Aug 18 13:19:25 2020 GMT
2020-08-18 13:19:25.577 |             Not After : Aug 18 13:19:25 2021 GMT
2020-08-18 13:19:25.577 |         Subject:
2020-08-18 13:19:25.577 |             commonName                = nbp
2020-08-18 13:19:25.577 |         X509v3 extensions:
2020-08-18 13:19:25.577 |             X509v3 Basic Constraints: 
2020-08-18 13:19:25.577 |                 CA:FALSE
2020-08-18 13:19:25.577 |             Netscape Comment: 
2020-08-18 13:19:25.577 |                 OpenSSL Generated Certificate
2020-08-18 13:19:25.577 |             X509v3 Subject Key Identifier: 
2020-08-18 13:19:25.577 |                 11:85:48:A7:EA:71:56:E1:17:D9:D0:40:31:C8:A1:03:A8:DD:BB:85
2020-08-18 13:19:25.577 |             X509v3 Authority Key Identifier: 
2020-08-18 13:19:25.577 |                 keyid:29:45:57:BB:1E:7B:C8:29:AB:AE:1D:06:EB:0C:E7:49:85:2A:D2:67
2020-08-18 13:19:25.577 | 
2020-08-18 13:19:25.577 | Certificate is to be certified until Aug 18 13:19:25 2021 GMT (365 days)
2020-08-18 13:19:25.578 | 
2020-08-18 13:19:25.578 | Write out database with 1 new entries
2020-08-18 13:19:25.579 | Data Base Updated
2020-08-18 13:19:25.579 | + openssl rsa -in /opt/soda-security/ca/nbp-key.pem -out /opt/soda-security/ca/nbp-key.pem -passin pass:xxxxx
2020-08-18 13:19:25.582 | writing RSA key
2020-08-18 13:19:25.583 | + mkdir -p /opt/soda-security/nbp
2020-08-18 13:19:25.584 | + mv /opt/soda-security/ca/nbp-key.pem /opt/soda-security/nbp/
2020-08-18 13:19:25.585 | + mv /opt/soda-security/ca/nbp-cert.pem /opt/soda-security/nbp/
2020-08-18 13:19:25.586 | + rm -rf /opt/soda-security/ca/nbp-csr.pem
2020-08-18 13:19:25.586 | + rm -rf /opt/soda-security/ca/demoCA
2020-08-18 13:19:25.587 | + for service in '$(echo $SUPPORT_SERVICES|tr '\'','\'' '\'' '\'')'
2020-08-18 13:19:25.587 | + soda::util::is_service_enabled keystone
2020-08-18 13:19:25.587 | + local enabled=1
2020-08-18 13:19:25.587 | + local services=keystone
2020-08-18 13:19:25.587 | + local service
2020-08-18 13:19:25.587 | + for service in '${services}'
2020-08-18 13:19:25.587 | + [[ ,opensds,etcd,certificate,keystone,lvm,nfs, =~ ,keystone, ]]
2020-08-18 13:19:25.587 | + enabled=0
2020-08-18 13:19:25.587 | + return 0
2020-08-18 13:19:25.587 | + source /root/installer/devsds/lib/keystone.sh
2020-08-18 13:19:25.589 | + soda::keystone::install
2020-08-18 13:19:25.589 | + '[' true == true ']'
2020-08-18 13:19:25.589 | + KEYSTONE_IP=192.168.1.101
2020-08-18 13:19:25.589 | + docker pull opensdsio/opensds-authchecker:latest
2020-08-18 13:19:30.394 | latest: Pulling from opensdsio/opensds-authchecker
2020-08-18 13:19:30.394 | Digest: sha256:342f5cd850e65fcd9d5ad0b435e3398f7ce1980bb7a08d3fd0e34ce72972de16
2020-08-18 13:19:30.394 | Status: Image is up to date for opensdsio/opensds-authchecker:latest
2020-08-18 13:19:30.395 | + docker run -d --privileged=true --net=host --name=opensds-authchecker opensdsio/opensds-authchecker:latest
2020-08-18 13:19:30.575 | af1715a2a7621294819e793499b9aa982306b0fa901f0002d7596e0d0588f458
2020-08-18 13:19:30.795 | + soda::keystone::opensds_conf
2020-08-18 13:19:30.795 | + cat
2020-08-18 13:19:30.796 | + cp /root/installer/devsds/examples/policy.json /etc/opensds
2020-08-18 13:19:30.797 | + docker cp /root/installer/devsds/lib/keystone.policy.json opensds-authchecker:/etc/keystone/policy.json
2020-08-18 13:19:31.141 | + for service in '$(echo $SUPPORT_SERVICES|tr '\'','\'' '\'' '\'')'
2020-08-18 13:19:31.141 | + soda::util::is_service_enabled lvm
2020-08-18 13:19:31.141 | + local enabled=1
2020-08-18 13:19:31.141 | + local services=lvm
2020-08-18 13:19:31.141 | + local service
2020-08-18 13:19:31.141 | + for service in '${services}'
2020-08-18 13:19:31.141 | + [[ ,opensds,etcd,certificate,keystone,lvm,nfs, =~ ,lvm, ]]
2020-08-18 13:19:31.141 | + enabled=0
2020-08-18 13:19:31.141 | + return 0
2020-08-18 13:19:31.141 | + source /root/installer/devsds/lib/lvm.sh
2020-08-18 13:19:31.147 | + soda::lvm::install
2020-08-18 13:19:31.147 | + local vg=opensds-volumes-default
2020-08-18 13:19:31.147 | + local fvg=opensds-files-default
2020-08-18 13:19:31.147 | + local size=20G
2020-08-18 13:19:31.147 | + soda::lvm::pkg_install
2020-08-18 13:19:31.147 | + sudo apt-get install -y lvm2 tgt open-iscsi ibverbs-utils
2020-08-18 13:19:31.205 | Reading package lists...
2020-08-18 13:19:31.650 | Building dependency tree...
2020-08-18 13:19:31.654 | Reading state information...
2020-08-18 13:19:32.136 | lvm2 is already the newest version (2.02.133-1ubuntu10).
2020-08-18 13:19:32.137 | ibverbs-utils is already the newest version (1.1.8-1.1ubuntu2).
2020-08-18 13:19:32.137 | open-iscsi is already the newest version (2.0.873+git0.3b4b4500-14ubuntu3.7).
2020-08-18 13:19:32.137 | tgt is already the newest version (1:1.0.63-1ubuntu1.1).
2020-08-18 13:19:32.137 | 0 upgraded, 0 newly installed, 0 to remove and 315 not upgraded.
2020-08-18 13:19:32.138 | + soda::nfs::pkg_install
2020-08-18 13:19:32.138 | + sudo apt-get install -y nfs-kernel-server
2020-08-18 13:19:32.196 | Reading package lists...
2020-08-18 13:19:32.660 | Building dependency tree...
2020-08-18 13:19:32.664 | Reading state information...
2020-08-18 13:19:33.123 | nfs-kernel-server is already the newest version (1:1.2.8-9ubuntu12.3).
2020-08-18 13:19:33.123 | 0 upgraded, 0 newly installed, 0 to remove and 315 not upgraded.
2020-08-18 13:19:33.125 | + soda::lvm::create_volume_group_for_file opensds-files-default 20G
2020-08-18 13:19:33.125 | + local fvg=opensds-files-default
2020-08-18 13:19:33.125 | + local size=20G
2020-08-18 13:19:33.125 | + local backing_file=/opt/sodafoundation/nfs/opensds-files-default-backing-file
2020-08-18 13:19:33.125 | + sudo vgs opensds-files-default
2020-08-18 13:19:33.132 |   Volume group "opensds-files-default" not found
2020-08-18 13:19:33.132 |   Cannot process volume group opensds-files-default
2020-08-18 13:19:33.134 | + [[ -f /opt/sodafoundation/nfs/opensds-files-default-backing-file ]]
2020-08-18 13:19:33.134 | + truncate -s 20G /opt/sodafoundation/nfs/opensds-files-default-backing-file
2020-08-18 13:19:33.137 | + local vg_dev
2020-08-18 13:19:33.137 | ++ sudo losetup -f --show /opt/sodafoundation/nfs/opensds-files-default-backing-file
2020-08-18 13:19:33.200 | + vg_dev=/dev/loop0
2020-08-18 13:19:33.200 | + sudo vgs opensds-files-default
2020-08-18 13:19:33.207 |   Volume group "opensds-files-default" not found
2020-08-18 13:19:33.207 |   Cannot process volume group opensds-files-default
2020-08-18 13:19:33.208 | + sudo vgcreate opensds-files-default /dev/loop0
2020-08-18 13:19:33.324 |   Physical volume "/dev/loop0" successfully created
2020-08-18 13:19:33.330 |   Volume group "opensds-files-default" successfully created
2020-08-18 13:19:33.332 | + soda::lvm::create_volume_group opensds-volumes-default 20G
2020-08-18 13:19:33.332 | + local vg=opensds-volumes-default
2020-08-18 13:19:33.332 | + local size=20G
2020-08-18 13:19:33.332 | + local backing_file=/opt/sodafoundation/lvm/opensds-volumes-default-backing-file
2020-08-18 13:19:33.332 | + sudo vgs opensds-volumes-default
2020-08-18 13:19:33.340 |   Volume group "opensds-volumes-default" not found
2020-08-18 13:19:33.340 |   Cannot process volume group opensds-volumes-default
2020-08-18 13:19:33.341 | + [[ -f /opt/sodafoundation/lvm/opensds-volumes-default-backing-file ]]
2020-08-18 13:19:33.341 | + truncate -s 20G /opt/sodafoundation/lvm/opensds-volumes-default-backing-file
2020-08-18 13:19:33.342 | + local vg_dev
2020-08-18 13:19:33.343 | ++ sudo losetup -f --show /opt/sodafoundation/lvm/opensds-volumes-default-backing-file
2020-08-18 13:19:33.402 | + vg_dev=/dev/loop1
2020-08-18 13:19:33.402 | + sudo vgs opensds-volumes-default
2020-08-18 13:19:33.413 |   Volume group "opensds-volumes-default" not found
2020-08-18 13:19:33.413 |   Cannot process volume group opensds-volumes-default
2020-08-18 13:19:33.414 | + sudo vgcreate opensds-volumes-default /dev/loop1
2020-08-18 13:19:33.494 |   Physical volume "/dev/loop1" successfully created
2020-08-18 13:19:33.512 |   Volume group "opensds-volumes-default" successfully created
2020-08-18 13:19:33.513 | + sudo tgtadm --op show --mode target
2020-08-18 13:19:33.513 | + awk '/Target/ {print $3}'
2020-08-18 13:19:33.513 | + sudo xargs -r -n1 tgt-admin --delete
2020-08-18 13:19:33.526 | + soda::lvm::remove_volumes opensds-volumes-default
2020-08-18 13:19:33.527 | + local vg=opensds-volumes-default
2020-08-18 13:19:33.527 | + sudo lvremove -f opensds-volumes-default
2020-08-18 13:19:33.552 | + soda::lvm::set_configuration
2020-08-18 13:19:33.552 | + cat
2020-08-18 13:19:33.553 | + cat
2020-08-18 13:19:33.554 | + soda::lvm::set_configuration_for_file
2020-08-18 13:19:33.554 | + cat
2020-08-18 13:19:33.555 | + cat
2020-08-18 13:19:33.556 | + local nvmevg=opensds-volumes-nvme
2020-08-18 13:19:33.556 | + [[ -e /dev/nvme0n1 ]]
2020-08-18 13:19:33.556 | + soda::lvm::set_lvm_filter
2020-08-18 13:19:33.556 | + local 'filter_suffix="r|.*|" ]  # from devsds'
2020-08-18 13:19:33.556 | + local 'filter_string=global_filter = [ '
2020-08-18 13:19:33.556 | + local pv
2020-08-18 13:19:33.556 | + local vg
2020-08-18 13:19:33.556 | + local line
2020-08-18 13:19:33.557 | ++ sudo pvs --noheadings -o name
2020-08-18 13:19:34.152 | + for pv_info in '$(sudo pvs --noheadings -o name)'
2020-08-18 13:19:34.152 | ++ sed 's/\/dev\///g'
2020-08-18 13:19:34.153 | ++ sed 's/ //g'
2020-08-18 13:19:34.153 | ++ echo -e /dev/loop0
2020-08-18 13:19:34.156 | + pv=loop0
2020-08-18 13:19:34.156 | + new='"a|loop0|", '
2020-08-18 13:19:34.156 | + filter_string='global_filter = [ "a|loop0|", '
2020-08-18 13:19:34.156 | + for pv_info in '$(sudo pvs --noheadings -o name)'
2020-08-18 13:19:34.156 | ++ sed 's/\/dev\///g'
2020-08-18 13:19:34.157 | ++ sed 's/ //g'
2020-08-18 13:19:34.158 | ++ echo -e /dev/loop1
2020-08-18 13:19:34.159 | + pv=loop1
2020-08-18 13:19:34.159 | + new='"a|loop1|", '
2020-08-18 13:19:34.159 | + filter_string='global_filter = [ "a|loop0|", "a|loop1|", '
2020-08-18 13:19:34.159 | + filter_string='global_filter = [ "a|loop0|", "a|loop1|", "r|.*|" ]  # from devsds'
2020-08-18 13:19:34.160 | + soda::lvm::clean_lvm_filter
2020-08-18 13:19:34.160 | + sudo sed -i 's/^.*# from devsds$//' /etc/lvm/lvm.conf
2020-08-18 13:19:34.175 | + sudo sed -i '/# global_filter = \[.*\]/a\    global_filter = [ "a|loop0|", "a|loop1|", "r|.*|" ]  # from devsds' /etc/lvm/lvm.conf
2020-08-18 13:19:34.190 | + soda::echo_summary 'set lvm.conf device global_filter to: global_filter = [ "a|loop0|", "a|loop1|", "r|.*|" ]  # from devsds'
2020-08-18 13:19:34.190 | + echo -e set lvm.conf device global_filter to: global_filter = '[' '"a|loop0|",' '"a|loop1|",' '"r|.*|"' ']' '#' from devsds
2020-08-18 13:19:34.190 | + for service in '$(echo $SUPPORT_SERVICES|tr '\'','\'' '\'' '\'')'
2020-08-18 13:19:34.190 | + soda::util::is_service_enabled ceph
2020-08-18 13:19:34.190 | + local enabled=1
2020-08-18 13:19:34.190 | + local services=ceph
2020-08-18 13:19:34.190 | + local service
2020-08-18 13:19:34.190 | + for service in '${services}'
2020-08-18 13:19:34.190 | + [[ ,opensds,etcd,certificate,keystone,lvm,nfs, =~ ,ceph, ]]
2020-08-18 13:19:34.190 | + return 1
2020-08-18 13:19:34.190 | + for service in '$(echo $SUPPORT_SERVICES|tr '\'','\'' '\'' '\'')'
2020-08-18 13:19:34.190 | + soda::util::is_service_enabled etcd
2020-08-18 13:19:34.190 | + local enabled=1
2020-08-18 13:19:34.190 | + local services=etcd
2020-08-18 13:19:34.190 | + local service
2020-08-18 13:19:34.190 | + for service in '${services}'
2020-08-18 13:19:34.190 | + [[ ,opensds,etcd,certificate,keystone,lvm,nfs, =~ ,etcd, ]]
2020-08-18 13:19:34.191 | + enabled=0
2020-08-18 13:19:34.191 | + return 0
2020-08-18 13:19:34.191 | + source /root/installer/devsds/lib/etcd.sh
2020-08-18 13:19:34.193 | + soda::etcd::install
2020-08-18 13:19:34.193 | + '[' '!' -f /opt/sodafoundation/bin/etcd ']'
2020-08-18 13:19:34.193 | + mkdir -p /opt/sodafoundation/etcd
2020-08-18 13:19:34.194 | + echo 12947
2020-08-18 13:19:34.194 | + soda::echo_summary 'Waiting for etcd to come up.'
2020-08-18 13:19:34.194 | + nohup /opt/sodafoundation/bin/etcd --advertise-client-urls http://192.168.1.101:62379 --listen-client-urls http://192.168.1.101:62379 --listen-peer-urls http://192.168.1.101:62380 --data-dir /opt/sodafoundation/etcd/data --debug
2020-08-18 13:19:34.194 | + echo -e Waiting for etcd to come up.
2020-08-18 13:19:34.194 | + soda::util::wait_for_url http://192.168.1.101:62379/v2/machines 'etcd: ' 0.25 80
2020-08-18 13:19:34.194 | + local url=http://192.168.1.101:62379/v2/machines
2020-08-18 13:19:34.194 | + local 'prefix=etcd: '
2020-08-18 13:19:34.194 | + local wait=0.25
2020-08-18 13:19:34.194 | + local times=80
2020-08-18 13:19:34.194 | + which curl
2020-08-18 13:19:34.196 | + local i
2020-08-18 13:19:34.196 | ++ seq 1 80
2020-08-18 13:19:34.197 | + for i in '$(seq 1 $times)'
2020-08-18 13:19:34.197 | + local out
2020-08-18 13:19:34.197 | ++ curl --max-time 1 -gkfs http://192.168.1.101:62379/v2/machines
2020-08-18 13:19:34.204 | + out=
2020-08-18 13:19:34.204 | + sleep 0.25
2020-08-18 13:19:34.457 | + for i in '$(seq 1 $times)'
2020-08-18 13:19:34.457 | + local out
2020-08-18 13:19:34.457 | ++ curl --max-time 1 -gkfs http://192.168.1.101:62379/v2/machines
2020-08-18 13:19:35.222 | + out=http://192.168.1.101:62379
2020-08-18 13:19:35.222 | + soda::echo_summary 'On try 2, etcd: : http://192.168.1.101:62379'
2020-08-18 13:19:35.222 | + echo -e On try 2, etcd: : http://192.168.1.101:62379
2020-08-18 13:19:35.222 | + return 0
2020-08-18 13:19:35.222 | + curl -fs -X PUT http://192.168.1.101:62379/v2/keys/_test
2020-08-18 13:19:35.226 | {"action":"set","node":{"key":"/_test","value":"","modifiedIndex":4,"createdIndex":4}}
2020-08-18 13:19:35.226 | + for service in '$(echo $SUPPORT_SERVICES|tr '\'','\'' '\'' '\'')'
2020-08-18 13:19:35.227 | + soda::util::is_service_enabled opensds
2020-08-18 13:19:35.227 | + local enabled=1
2020-08-18 13:19:35.227 | + local services=opensds
2020-08-18 13:19:35.227 | + local service
2020-08-18 13:19:35.227 | + for service in '${services}'
2020-08-18 13:19:35.227 | + [[ ,opensds,etcd,certificate,keystone,lvm,nfs, =~ ,opensds, ]]
2020-08-18 13:19:35.227 | + enabled=0
2020-08-18 13:19:35.227 | + return 0
2020-08-18 13:19:35.227 | + source /root/installer/devsds/lib/opensds.sh
2020-08-18 13:19:35.228 | + soda::opensds::install
2020-08-18 13:19:35.228 | + soda:opensds:configuration
2020-08-18 13:19:35.228 | + SODA_API_DIR=/opt/opensds-hotpot-linux-amd64
2020-08-18 13:19:35.228 | + cp /opt/opensds-hotpot-linux-amd64/swagger.yaml /etc/opensds
2020-08-18 13:19:35.229 | + cat
2020-08-18 13:19:35.230 | + cd /opt/opensds-hotpot-linux-amd64
2020-08-18 13:19:35.230 | + sudo bin/osdsapiserver --daemon
2020-08-18 13:19:35.242 | bin/osdsapiserver [PID] 13082 running...
2020-08-18 13:19:35.244 | + sudo bin/osdslet --daemon
2020-08-18 13:19:35.255 | bin/osdslet [PID] 13098 running...
2020-08-18 13:19:35.260 | + sudo bin/osdsdock --daemon
2020-08-18 13:19:35.290 | 2020/08/18 18:49:35 Command: modprobe nvme-rdma:
2020-08-18 13:19:35.291 | bin/osdsdock [PID] 13125 running...
2020-08-18 13:19:35.294 | + soda::echo_summary 'Waiting for osdsapiserver to come up.'
2020-08-18 13:19:35.294 | + echo -e Waiting for osdsapiserver to come up.
2020-08-18 13:19:35.294 | + soda::util::wait_for_url localhost:50040 osdsapiserver 0.5 80
2020-08-18 13:19:35.294 | + local url=localhost:50040
2020-08-18 13:19:35.294 | + local prefix=osdsapiserver
2020-08-18 13:19:35.294 | + local wait=0.5
2020-08-18 13:19:35.294 | + local times=80
2020-08-18 13:19:35.294 | + which curl
2020-08-18 13:19:35.302 | + local i
2020-08-18 13:19:35.302 | ++ seq 1 80
2020-08-18 13:19:35.302 | + for i in '$(seq 1 $times)'
2020-08-18 13:19:35.302 | + local out
2020-08-18 13:19:35.305 | ++ curl --max-time 1 -gkfs localhost:50040
2020-08-18 13:19:35.318 | + out=
2020-08-18 13:19:35.318 | + sleep 0.5
2020-08-18 13:19:35.819 | + for i in '$(seq 1 $times)'
2020-08-18 13:19:35.819 | + local out
2020-08-18 13:19:35.819 | ++ curl --max-time 1 -gkfs localhost:50040
2020-08-18 13:19:35.828 | + out='[{"description":"v1beta version","name":"v1beta","status":"CURRENT","updatedAt":"2017-07-10T14:36:58.014Z"}]'
2020-08-18 13:19:35.828 | + soda::echo_summary 'On try 2, osdsapiserver: [{"description":"v1beta version","name":"v1beta","status":"CURRENT","updatedAt":"2017-07-10T14:36:58.014Z"}]'
2020-08-18 13:19:35.828 | + echo -e On try 2, osdsapiserver: '[{"description":"v1beta' 'version","name":"v1beta","status":"CURRENT","updatedAt":"2017-07-10T14:36:58.014Z"}]'
2020-08-18 13:19:35.828 | + return 0
2020-08-18 13:19:35.828 | + '[' keystone == keystone ']'
2020-08-18 13:19:35.828 | + '[' true == true ']'
2020-08-18 13:19:35.828 | + KEYSTONE_IP=192.168.1.101
2020-08-18 13:19:35.828 | + export OS_AUTH_URL=http://192.168.1.101/identity
2020-08-18 13:19:35.828 | + OS_AUTH_URL=http://192.168.1.101/identity
2020-08-18 13:19:35.828 | + export OS_USERNAME=admin
2020-08-18 13:19:35.828 | + OS_USERNAME=admin
2020-08-18 13:19:35.828 | + export OS_PASSWORD=opensds@123
2020-08-18 13:19:35.828 | + OS_PASSWORD=opensds@123
2020-08-18 13:19:35.828 | + export OS_TENANT_NAME=admin
2020-08-18 13:19:35.829 | + OS_TENANT_NAME=admin
2020-08-18 13:19:35.829 | + export OS_PROJECT_NAME=admin
2020-08-18 13:19:35.829 | + OS_PROJECT_NAME=admin
2020-08-18 13:19:35.829 | + export OS_USER_DOMAIN_ID=default
2020-08-18 13:19:35.829 | + OS_USER_DOMAIN_ID=default
2020-08-18 13:19:35.829 | + cp osdsctl.bash_completion /etc/bash_completion.d/
2020-08-18 13:19:35.829 | + export OPENSDS_AUTH_STRATEGY=keystone
2020-08-18 13:19:35.829 | + OPENSDS_AUTH_STRATEGY=keystone
2020-08-18 13:19:35.829 | + export OPENSDS_ENDPOINT=http://localhost:50040
2020-08-18 13:19:35.829 | + OPENSDS_ENDPOINT=http://localhost:50040
2020-08-18 13:19:35.829 | + /opt/opensds-hotpot-linux-amd64/bin/osdsctl profile create '{"name": "default_block", "description": "default policy", "storageType": "block"}'
2020-08-18 13:19:36.170 | +--------------------------+--------------------------------------+
2020-08-18 13:19:36.170 | | Property                 | Value                                |
2020-08-18 13:19:36.170 | +--------------------------+--------------------------------------+
2020-08-18 13:19:36.170 | | Id                       | c2657411-b771-4f34-bd47-98d5bceafe99 |
2020-08-18 13:19:36.170 | | CreatedAt                | 2020-08-18T18:49:36                  |
2020-08-18 13:19:36.170 | | Name                     | default_block                        |
2020-08-18 13:19:36.170 | | Description              | default policy                       |
2020-08-18 13:19:36.170 | | StorageType              | block                                |
2020-08-18 13:19:36.170 | | ProvisioningProperties   | {                                    |
2020-08-18 13:19:36.170 | |                          |   "dataStorage": {                   |
2020-08-18 13:19:36.170 | |                          |     "compression": false,            |
2020-08-18 13:19:36.170 | |                          |     "deduplication": false           |
2020-08-18 13:19:36.170 | |                          |   },                                 |
2020-08-18 13:19:36.170 | |                          |   "ioConnectivity": {}               |
2020-08-18 13:19:36.170 | |                          | }                                    |
2020-08-18 13:19:36.170 | |                          |                                      |
2020-08-18 13:19:36.170 | | ReplicationProperties    | {                                    |
2020-08-18 13:19:36.170 | |                          |   "dataProtection": {                |
2020-08-18 13:19:36.170 | |                          |     "isIsolated": false              |
2020-08-18 13:19:36.170 | |                          |   },                                 |
2020-08-18 13:19:36.170 | |                          |   "replicaInfos": {}                 |
2020-08-18 13:19:36.170 | |                          | }                                    |
2020-08-18 13:19:36.170 | |                          |                                      |
2020-08-18 13:19:36.170 | | SnapshotProperties       | {                                    |
2020-08-18 13:19:36.170 | |                          |   "schedule": {},                    |
2020-08-18 13:19:36.170 | |                          |   "retention": {},                   |
2020-08-18 13:19:36.170 | |                          |   "topology": {}                     |
2020-08-18 13:19:36.170 | |                          | }                                    |
2020-08-18 13:19:36.170 | |                          |                                      |
2020-08-18 13:19:36.170 | | DataProtectionProperties | {                                    |
2020-08-18 13:19:36.170 | |                          |   "dataProtection": {                |
2020-08-18 13:19:36.170 | |                          |     "isIsolated": false              |
2020-08-18 13:19:36.170 | |                          |   }                                  |
2020-08-18 13:19:36.170 | |                          | }                                    |
2020-08-18 13:19:36.170 | |                          |                                      |
2020-08-18 13:19:36.170 | | CustomProperties         | null                                 |
2020-08-18 13:19:36.170 | |                          |                                      |
2020-08-18 13:19:36.170 | +--------------------------+--------------------------------------+
2020-08-18 13:19:36.171 | + /opt/opensds-hotpot-linux-amd64/bin/osdsctl profile create '{"name": "default_file", "description": "default policy", "storageType": "file", "provisioningProperties":{"ioConnectivity": {"accessProtocol": "NFS"},"DataStorage":{"StorageAccessCapability":["Read","Write","Execute"]}}}'
2020-08-18 13:19:36.274 | +--------------------------+--------------------------------------+
2020-08-18 13:19:36.274 | | Property                 | Value                                |
2020-08-18 13:19:36.274 | +--------------------------+--------------------------------------+
2020-08-18 13:19:36.274 | | Id                       | cbae1595-381e-4d9f-bc8d-3c1256a5a32a |
2020-08-18 13:19:36.274 | | CreatedAt                | 2020-08-18T18:49:36                  |
2020-08-18 13:19:36.274 | | Name                     | default_file                         |
2020-08-18 13:19:36.274 | | Description              | default policy                       |
2020-08-18 13:19:36.274 | | StorageType              | file                                 |
2020-08-18 13:19:36.274 | | ProvisioningProperties   | {                                    |
2020-08-18 13:19:36.274 | |                          |   "dataStorage": {                   |
2020-08-18 13:19:36.274 | |                          |     "storageAccessCapability": [     |
2020-08-18 13:19:36.274 | |                          |       "Read",                        |
2020-08-18 13:19:36.274 | |                          |       "Write",                       |
2020-08-18 13:19:36.274 | |                          |       "Execute"                      |
2020-08-18 13:19:36.274 | |                          |     ],                               |
2020-08-18 13:19:36.274 | |                          |     "compression": false,            |
2020-08-18 13:19:36.274 | |                          |     "deduplication": false           |
2020-08-18 13:19:36.274 | |                          |   },                                 |
2020-08-18 13:19:36.274 | |                          |   "ioConnectivity": {                |
2020-08-18 13:19:36.274 | |                          |     "accessProtocol": "NFS"          |
2020-08-18 13:19:36.274 | |                          |   }                                  |
2020-08-18 13:19:36.274 | |                          | }                                    |
2020-08-18 13:19:36.274 | |                          |                                      |
2020-08-18 13:19:36.274 | | ReplicationProperties    | {                                    |
2020-08-18 13:19:36.274 | |                          |   "dataProtection": {                |
2020-08-18 13:19:36.274 | |                          |     "isIsolated": false              |
2020-08-18 13:19:36.274 | |                          |   },                                 |
2020-08-18 13:19:36.274 | |                          |   "replicaInfos": {}                 |
2020-08-18 13:19:36.274 | |                          | }                                    |
2020-08-18 13:19:36.274 | |                          |                                      |
2020-08-18 13:19:36.274 | | SnapshotProperties       | {                                    |
2020-08-18 13:19:36.274 | |                          |   "schedule": {},                    |
2020-08-18 13:19:36.274 | |                          |   "retention": {},                   |
2020-08-18 13:19:36.274 | |                          |   "topology": {}                     |
2020-08-18 13:19:36.274 | |                          | }                                    |
2020-08-18 13:19:36.274 | |                          |                                      |
2020-08-18 13:19:36.274 | | DataProtectionProperties | {                                    |
2020-08-18 13:19:36.275 | |                          |   "dataProtection": {                |
2020-08-18 13:19:36.275 | |                          |     "isIsolated": false              |
2020-08-18 13:19:36.275 | |                          |   }                                  |
2020-08-18 13:19:36.275 | |                          | }                                    |
2020-08-18 13:19:36.275 | |                          |                                      |
2020-08-18 13:19:36.275 | | CustomProperties         | null                                 |
2020-08-18 13:19:36.275 | |                          |                                      |
2020-08-18 13:19:36.275 | +--------------------------+--------------------------------------+


Execute commands below to set up ENVs which are needed by SODA CLI:
------------------------------------------------------------------
export OPENSDS_AUTH_STRATEGY=keystone
export OPENSDS_ENDPOINT=http://localhost:50040
export OS_AUTH_URL=http://192.168.1.101/identity
export OS_USERNAME=admin
export OS_PASSWORD=opensds@123
export OS_TENANT_NAME=admin
export OS_PROJECT_NAME=admin
export OS_USER_DOMAIN_ID=default
------------------------------------------------------------------
Enjoy it !!

2020-08-18 13:19:36.278 | + '[' 0 == 0 ']'
2020-08-18 13:19:36.278 | + soda::echo_summary devsds installed successfully '!!'
2020-08-18 13:19:36.278 | + echo -e devsds installed successfully '!!'
2020-08-18 13:19:36.278 | + :

```
**Special notes for your reviewer**:
