### PR TITLE
Adding support for NetApp NAS as backend installation

### DIFF
--- a/ansible/group_vars/netapp/ontap/ontap_nas.yaml
+++ b/ansible/group_vars/netapp/ontap/ontap_nas.yaml
@@ -1,0 +1,32 @@
+backendOptions:
+  version: 1
+  username: "username"
+  password: "password"
+  storageDriverName: "ontap-nas"
+  managementLIF: "1.2.3.4"
+  dataLIF: "1.2.3.5"
+  svm: "soda-svm"
+pool:
+  soda-pool:
+    storageType: file
+    availabilityZone: default
+    multiAttach: true
+    extras:
+      dataStorage:
+        provisioningPolicy: Thin
+        compression: false
+        deduplication: false
+        storageAccessCapability:
+          - Read
+          - Write
+          - Execute
+      ioConnectivity:
+        accessProtocol: nfs
+        maxIOPS: 7000000
+        maxBWS: 600
+        minIOPS: 1000000
+        minBWS: 100
+        latency: 100
+      advanced:
+        diskType: SSD
+        latency: 5ms

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -22,7 +22,7 @@ dummy:
 # GENERAL #
 ###########
 
-# Change it according to your backend, currently support 'lvm', 'ceph', 'cinder', 'nfs', 'netapp_ontap_san'
+# Change it according to your backend, currently support 'lvm', 'ceph', 'cinder', 'nfs', 'netapp_ontap_san', 'netapp_ontap_nas'
 # DISABLE OR COMMENT "enabled_backends: lvm" IF YOU WANT TO INSTALL DIFFERENT BACKENDS ON MULTI-NODES AND mention it in "local.hosts" file
 # Comment this part if you want to use different backends on different nodes
 enabled_backends: lvm,nfs #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder,nfs
@@ -124,3 +124,15 @@ ontap_name: netapp ontap backend
 ontap_description: This is a netapp ontap san backend service
 ontap_driver_name: netapp_ontap_san
 ontap_config_path: "{{ opensds_driver_config_dir }}/netapp_ontap_san.yaml"
+
+
+#####################
+#  NetApp ONTAP NAS #
+#####################
+
+
+# These fields are NOT suggested to be modified
+ontap_name: netapp ontap backend
+ontap_description: This is a netapp ontap nas backend service
+ontap_driver_name: netapp_ontap_nas
+ontap_config_path: "{{ opensds_driver_config_dir }}/netapp_ontap_nas.yaml"

--- a/ansible/group_vars/osdsdock.yml
+++ b/ansible/group_vars/osdsdock.yml
@@ -25,7 +25,7 @@ dummy:
 # Change it according to your backend, currently support 'lvm', 'ceph', 'cinder', 'nfs', 'netapp_ontap_san', 'netapp_ontap_nas'
 # DISABLE OR COMMENT "enabled_backends: lvm" IF YOU WANT TO INSTALL DIFFERENT BACKENDS ON MULTI-NODES AND mention it in "local.hosts" file
 # Comment this part if you want to use different backends on different nodes
-enabled_backends: lvm,nfs #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder,nfs
+enabled_backends: netapp_ontap_nas #For Multi-backend add backends here, for eg. enabled_backends: lvm,ceph,cinder,nfs
 
 # Change it according to your node type (host or target), currently support
 # 'provisioner', 'attacher'
@@ -132,7 +132,7 @@ ontap_config_path: "{{ opensds_driver_config_dir }}/netapp_ontap_san.yaml"
 
 
 # These fields are NOT suggested to be modified
-ontap_name: netapp ontap backend
-ontap_description: This is a netapp ontap nas backend service
-ontap_driver_name: netapp_ontap_nas
-ontap_config_path: "{{ opensds_driver_config_dir }}/netapp_ontap_nas.yaml"
+ontap_nas_name: netapp ontap backend
+ontap_nas_description: This is a netapp ontap nas backend service
+ontap_nas_driver_name: netapp_ontap_nas
+ontap_nas_config_path: "{{ opensds_driver_config_dir }}/netapp_ontap_nas.yaml"

--- a/ansible/roles/osdsdock/scenarios/ontap.yml
+++ b/ansible/roles/osdsdock/scenarios/ontap.yml
@@ -38,4 +38,4 @@
     regexp: "{{ item.regexp }}"
     replace: "{{ item.replace }}"
   with_items:
-    - { regexp: '127.0.0.1', replace: '{{host_ip}}'}
+    - { regexp: '127.0.0.1', replace: '{{ host_ip }}'}

--- a/ansible/roles/osdsdock/scenarios/ontap_nas.yml
+++ b/ansible/roles/osdsdock/scenarios/ontap_nas.yml
@@ -1,0 +1,41 @@
+# Copyright 2020 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: configure soda global info osdsdock ontap nas
+  ini_file:
+    path: "{{ opensds_conf_file }}"
+    section: netapp_ontap_nas
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+  with_items:
+        - { option: name, value: "{{ ontap_name }}" }
+        - { option: description, value: "{{ ontap_description }}" }
+        - { option: driver_name, value: "{{ ontap_driver_name }}" }
+        - { option: config_path, value: "{{ ontap_config_path }}" }
+  become: yes
+
+- name: copy soda ontap backend file to ontap config path if specify ontap nas as backend
+  copy:
+    src: ../../../group_vars/netapp/ontap/ontap_nas.yaml
+    dest: "{{ ontap_config_path }}"
+
+- name: update soda ontap backend file if specify ontap nas backend
+  replace:
+    path: "{{ ontap_config_path }}"
+    regexp: "{{ item.regexp }}"
+    replace: "{{ item.replace }}"
+  with_items:
+    - { regexp: '127.0.0.1', replace: '{{host_ip}}'}

--- a/ansible/roles/osdsdock/scenarios/ontap_nas.yml
+++ b/ansible/roles/osdsdock/scenarios/ontap_nas.yml
@@ -21,21 +21,21 @@
     option: "{{ item.option }}"
     value: "{{ item.value }}"
   with_items:
-        - { option: name, value: "{{ ontap_name }}" }
-        - { option: description, value: "{{ ontap_description }}" }
-        - { option: driver_name, value: "{{ ontap_driver_name }}" }
-        - { option: config_path, value: "{{ ontap_config_path }}" }
+        - { option: name, value: "{{ ontap_nas_name }}" }
+        - { option: description, value: "{{ ontap_nas_description }}" }
+        - { option: driver_name, value: "{{ ontap_nas_driver_name }}" }
+        - { option: config_path, value: "{{ ontap_nas_config_path }}" }
   become: yes
 
 - name: copy soda ontap backend file to ontap config path if specify ontap nas as backend
   copy:
     src: ../../../group_vars/netapp/ontap/ontap_nas.yaml
-    dest: "{{ ontap_config_path }}"
+    dest: "{{ ontap_nas_config_path }}"
 
 - name: update soda ontap backend file if specify ontap nas backend
   replace:
-    path: "{{ ontap_config_path }}"
+    path: "{{ ontap_nas_config_path }}"
     regexp: "{{ item.regexp }}"
     replace: "{{ item.replace }}"
   with_items:
-    - { regexp: '127.0.0.1', replace: '{{host_ip}}'}
+    - { regexp: '127.0.0.1', replace: '{{ host_ip }}'}

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -38,6 +38,12 @@
   when:
     - "'netapp_ontap_san' in enabled_backends"
 
+- name: include scenarios/ontap_nas.yml
+  include: scenarios/ontap_nas.yml
+  when:
+    - "'netapp_ontap_nas' in enabled_backends"
+
+
 - name: include scenarios/cinder_standalone.yml
   include: scenarios/cinder_standalone.yml
   when:


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind new feature
> /kind bug fix
> /kind cleanup
> /kind revert change
> /kind design
> /kind documentation
> /kind enhancement

**What this PR does / why we need it**:
This adds support for adding NetApp NAS as storage backend while installing through Ansible. 

**Which issue(s) this PR fixes**:
Fixes #384 

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
/kind TESTED
> /kind NOT-TESTED

**Test Report**:
```
root@aks:~/gopath/src/github.com/sodafoundation/installer/ansible# osdsctl dock list
+--------------------------------------+----------------------+--------------------------------------------+-----------------+------------------+
| Id                                   | Name                 | Description                                | Endpoint        | DriverName       |
+--------------------------------------+----------------------+--------------------------------------------+-----------------+------------------+
| c7087ab0-1a25-5ef1-af14-721ff007e0fc | netapp ontap backend | This is a netapp ontap nas backend service | localhost:50050 | netapp_ontap_nas |
+--------------------------------------+----------------------+--------------------------------------------+-----------------+------------------+
root@aks:~/gopath/src/github.com/sodafoundation/installer/ansible# osdsctl pool list
+--------------------------------------+-------+-------------+-----------+---------------+--------------+
| Id                                   | Name  | Description | Status    | TotalCapacity | FreeCapacity |
+--------------------------------------+-------+-------------+-----------+---------------+--------------+
| aacfcf3b-330b-552f-aa2c-73c2bd5ae5b5 | aggr0 |             | available | 8             | 7            |
+--------------------------------------+-------+-------------+-----------+---------------+--------------+
root@aks:~/gopath/src/github.com/sodafoundation/installer/ansible# osdsctl fileshare list
+--------------------------------------+------+-----------+-------------+------+-----------+--------------------------------------+----------------------+
| Id                                   | Name | Protocols | Description | Size | Status    | ProfileId                            | ExportLocations      |
+--------------------------------------+------+-----------+-------------+------+-----------+--------------------------------------+----------------------+
| cc99afc0-7659-4709-8bf6-a879c0699b4b | vol1 | [nfs]     |             | 1    | available | 0b07846b-08e8-430f-8d5c-476bad6c6f40 | [192.168.21.8:/vol1] |
+--------------------------------------+------+-----------+-------------+------+-----------+--------------------------------------+----------------------+
root@aks:~/gopath/src/github.com/sodafoundation/installer/ansible# ps -eaf |grep osds
root     2404849       1  0 18:15 pts/2    00:00:00 bin/osdslet
root     2404891       1  0 18:15 pts/2    00:00:01 bin/osdsapiserver
root     2405543       1  0 18:15 pts/2    00:00:04 bin/osdsdock
root     2458073 2177654  0 20:46 pts/2    00:00:00 grep --color=auto osds
root@aks:~/gopath/src/github.com/sodafoundation/installer/ansible# ls /etc/opensds/driver/
netapp_ontap_nas.yaml
root@aks:~/gopath/src/github.com/sodafoundation/installer/ansible#
```

**Special notes for your reviewer**:
