### PR TITLE
Fixed issue with uninstall SRM toolchain when not exists

### DIFF
--- a/ansible/roles/cleaner/scenarios/srm-toolchain.yml
+++ b/ansible/roles/cleaner/scenarios/srm-toolchain.yml
@@ -24,6 +24,8 @@
     chdir: "{{ srm_toolchain_work_dir }}/"
   when:
     - source_purge == false
+    - srmtoolchainexisted.stat.isdir is defined and srmtoolchainexisted.stat.isdir
+
 
 - name: Stop and remove Prometheus, Alertmanager, Grafana containers & delete the images
   shell: docker-compose down --rmi all
@@ -31,6 +33,7 @@
     chdir: "{{ srm_toolchain_work_dir }}/"
   when:
     - source_purge is undefined or source_purge != false
+    - srmtoolchainexisted.stat.isdir is defined and srmtoolchainexisted.stat.isdir
 
 - name: clean up all SRM Toolchain directories
   file:
@@ -45,3 +48,5 @@
     - clean
   when:
     - source_purge is undefined or source_purge != false
+    - srmtoolchainexisted.stat.isdir is defined and srmtoolchainexisted.stat.isdir
+    

--- a/ansible/roles/cleaner/scenarios/srm-toolchain.yml
+++ b/ansible/roles/cleaner/scenarios/srm-toolchain.yml
@@ -15,7 +15,7 @@
 ---
 - name: check for SRM Toolchain files existed
   stat:
-    path: "{{ srm_toolchain_work_dir }}/docker-compose.yml"
+    path: "{{ srm_toolchain_work_dir }}"
   register: srmtoolchainexisted
 
 - name: Stop and remove Prometheus, Alertmanager, Grafana containers but don't delete the images

--- a/ansible/roles/cleaner/scenarios/srm-toolchain.yml
+++ b/ansible/roles/cleaner/scenarios/srm-toolchain.yml
@@ -26,7 +26,6 @@
     - source_purge == false
     - srmtoolchainexisted.stat.isdir is defined and srmtoolchainexisted.stat.isdir
 
-
 - name: Stop and remove Prometheus, Alertmanager, Grafana containers & delete the images
   shell: docker-compose down --rmi all
   args:

--- a/ansible/roles/gelato-installer/scenarios/repository.yml
+++ b/ansible/roles/gelato-installer/scenarios/repository.yml
@@ -38,7 +38,7 @@
     - gelatoexisted.stat.exists is undefined or gelatoexisted.stat.exists == false
 
 - name: build gelato docker images
-  shell: make docker
+  shell: make docker -d
   environment:
     GOPATH: "{{ go_path }}"
   args:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
This PR fixes the issue of SRM Toolchain uninstall failing to delete the /opt/srm-toolchain folder even when SRM toolchain has not been installed.

The SRM toolchain uninstaller was executing change to and  delete folder even when the folder was not created. This was due to a missing check on the folder existence.
This has been added.
**Which issue(s) this PR fixes**:
Fixes #417 

**Test Report Added?**:
 /kind TESTED

**Test Report**:

**Special notes for your reviewer**:
