### PR TITLE
Fixed dashboard installation when auth strategy is noauth

### DIFF
--- a/ansible/roles/dashboard-installer/tasks/main.yml
+++ b/ansible/roles/dashboard-installer/tasks/main.yml
@@ -15,11 +15,18 @@
 ---
 - name: use container to install dashboard
   include_tasks: scenarios/container.yml
-  when: dashboard_installation_type == "container"
+  when: 
+    - dashboard_installation_type == "container"
+    - opensds_auth_strategy == "keystone"
 
 - name: use source code to install dashboard
   include_tasks: scenarios/source-code.yml
-  when: dashboard_installation_type == "source_code"
+  when: 
+    - dashboard_installation_type == "source_code"
+    - opensds_auth_strategy == "keystone"
 
 - name: login console
   debug: msg="please use '{{ console_login_url }}' login console"
+  when: 
+    - dashboard_installation_type == "container" or dashboard_installation_type == "source_code"
+    - opensds_auth_strategy == "keystone"

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -159,6 +159,7 @@
   remote_user: root
   vars_files:
     - group_vars/common.yml
+    - group_vars/auth.yml
     - group_vars/srm-toolchain.yml
     - group_vars/dashboard.yml
   gather_facts: false


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR fixes the dashboard installation issue when auth strategy is set to noauth.
When the auth strategy is set to noauth the dashboard will not be installed. If user wishes to install dashboard they can then install keystone and dashboard using the tags.

**Which issue(s) this PR fixes**:
Fixes #419 

**Test Report Added?**:
/kind TESTED


**Test Report**:

**Special notes for your reviewer**:
