### PR TITLE
Updated the default grafana dashboards to show connected graphs instead of with breaks

### DIFF
--- a/ansible/srm-toolchain/grafana/dashboards/default-dashboard.json
+++ b/ansible/srm-toolchain/grafana/dashboards/default-dashboard.json
@@ -84,7 +84,7 @@
         "lines": true,
         "linewidth": 1,
         "maxPerRow": 3,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -217,7 +217,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -329,7 +329,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -441,7 +441,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -568,7 +568,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -680,7 +680,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -792,7 +792,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },

--- a/ansible/srm-toolchain/grafana/dashboards/storage-details-dashboard.json
+++ b/ansible/srm-toolchain/grafana/dashboards/storage-details-dashboard.json
@@ -84,7 +84,7 @@
         "lines": true,
         "linewidth": 1,
         "maxPerRow": 3,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -217,7 +217,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -329,7 +329,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -441,7 +441,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -568,7 +568,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -680,7 +680,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },
@@ -792,7 +792,7 @@
         },
         "lines": true,
         "linewidth": 1,
-        "nullPointMode": "null",
+        "nullPointMode": "connected",
         "options": {
           "alertThreshold": true
         },


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR fixes the default grafana dashboard display to show continuous graphs even though the collection of metrics happens once every 15 minutes. instead of showing gaps in the grafana charts we now show a connected graph.

**Which issue(s) this PR fixes**:
Fixes #

**Test Report Added?**:
/kind TESTED


**Test Report**:
![image](https://user-images.githubusercontent.com/19162717/112843921-c1887c00-90c0-11eb-9b87-ea389a99aa0b.png)

![image](https://user-images.githubusercontent.com/19162717/112843932-c4836c80-90c0-11eb-9d33-5e11594ace06.png)

**Special notes for your reviewer**:
