### PR TITLE
Updated the Grafana viewing window from last 30m to 24h

### DIFF
--- a/ansible/srm-toolchain/grafana/dashboards/default-dashboard.json
+++ b/ansible/srm-toolchain/grafana/dashboards/default-dashboard.json
@@ -874,7 +874,7 @@
       ]
     },
     "time": {
-      "from": "now-1h",
+      "from": "now-24h",
       "to": "now"
     },
     "timepicker": {

--- a/ansible/srm-toolchain/grafana/dashboards/storage-details-dashboard.json
+++ b/ansible/srm-toolchain/grafana/dashboards/storage-details-dashboard.json
@@ -881,7 +881,7 @@
       ]
     },
     "time": {
-      "from": "now-30m",
+      "from": "now-24h",
       "to": "now"
     },
     "timepicker": {


### PR DESCRIPTION

**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR updates the viewing window of Grafana dashboards from last 30 minutes to last 24hours.
The metrics are being generated every 15minutes now and there may be times when the last 30 minutes may not have any data points. For this the viewing window is now increased to 24 hours.

**Which issue(s) this PR fixes**:
Fixes #

**Test Report Added?**:
/kind TESTED

**Test Report**:
![image](https://user-images.githubusercontent.com/19162717/113377681-9fc61800-9392-11eb-84a7-8d299cf5df7f.png)

**Special notes for your reviewer**:
