### PR TITLE
Added restart always policy to api, controller, dock, authchecker and etcd containers to improve the reliability of SODA services when deployed as containers

### DIFF
--- a/ansible/roles/cleaner/tasks/main.yml
+++ b/ansible/roles/cleaner/tasks/main.yml
@@ -72,7 +72,7 @@
     state: absent
     force: yes
   ignore_errors: yes
-  when: install_from != "container" database_purge is undefined or database_purge == true
+  when: install_from != "container" and database_purge is undefined or database_purge == true
   tags: hotpot
 
 - name: stop all gelato services

--- a/ansible/roles/cleaner/tasks/main.yml
+++ b/ansible/roles/cleaner/tasks/main.yml
@@ -51,13 +51,28 @@
   when: install_from == "container"
   tags: hotpot
 
+- name: kill etcd containerized service
+  docker_container:
+    name: soda-etcd
+    image: "{{ etcd_docker_image }}"
+    state: absent
+  when: install_from == "container"
+  tags: hotpot
+
+- name: remove etcd volume when installed as containerized service
+  docker_volume:
+    name: etcd_data
+    state: absent
+  when: install_from == "container" and database_purge is undefined or database_purge == true
+  tags: hotpot
+
 - name: clean etcd db resource
   file:
     path: "{{ etcd_dir }}"
     state: absent
     force: yes
   ignore_errors: yes
-  when: database_purge is undefined or database_purge == true
+  when: install_from != "container" database_purge is undefined or database_purge == true
   tags: hotpot
 
 - name: stop all gelato services

--- a/ansible/roles/hotpot-installer/scenarios/container.yml
+++ b/ansible/roles/hotpot-installer/scenarios/container.yml
@@ -23,6 +23,7 @@
     image: "{{ controller_docker_image }}"
     state: started
     network_mode: host
+    restart_policy: always
     volumes:
     - "/etc/opensds/:/etc/opensds"
 
@@ -32,5 +33,6 @@
     image: "{{ apiserver_docker_image }}"
     state: started
     network_mode: host
+    restart_policy: always
     volumes:
     - "/etc/opensds/:/etc/opensds"

--- a/ansible/roles/osdsdb/scenarios/container.yml
+++ b/ansible/roles/osdsdb/scenarios/container.yml
@@ -18,11 +18,16 @@
     name: docker-py
 - name: run etcd containerized service
   docker_container:
-    name: myetcd
+    name: soda-etcd
     image: "{{ etcd_docker_image }}"
-    command: /usr/local/bin/etcd --advertise-client-urls http://{{ etcd_host }}:{{ etcd_port }} --listen-client-urls http://{{ etcd_host }}:{{ etcd_port }} --listen-peer-urls http://{{ etcd_host }}:{{ etcd_peer_port }}
     state: started
-    network_mode: host
     restart_policy: always
+    network_mode: host
     volumes:
     - "/usr/share/ca-certificates/:/etc/ssl/certs"
+    - "etcd_data:/var/lib/etcd/"
+    env:
+      ETCD_LISTEN_CLIENT_URLS: http://{{ etcd_host }}:{{ etcd_port }}
+      ETCD_LISTEN_PEER_URLS: http://{{ etcd_host }}:{{ etcd_peer_port }}
+      ETCD_ADVERTISE_CLIENT_URLS: http://{{ etcd_host }}:{{ etcd_port }}
+      ETCD_DATA_DIR: /var/lib/etcd

--- a/ansible/roles/osdsdb/scenarios/container.yml
+++ b/ansible/roles/osdsdb/scenarios/container.yml
@@ -23,5 +23,6 @@
     command: /usr/local/bin/etcd --advertise-client-urls http://{{ etcd_host }}:{{ etcd_port }} --listen-client-urls http://{{ etcd_host }}:{{ etcd_port }} --listen-peer-urls http://{{ etcd_host }}:{{ etcd_peer_port }}
     state: started
     network_mode: host
+    restart_policy: always
     volumes:
     - "/usr/share/ca-certificates/:/etc/ssl/certs"

--- a/ansible/roles/osdsdock/tasks/main.yml
+++ b/ansible/roles/osdsdock/tasks/main.yml
@@ -108,6 +108,7 @@
     image: "{{ dock_docker_image }}"
     state: started
     network_mode: host
+    restart_policy: always 
     privileged: true
     volumes:
     - "/etc/opensds:/etc/opensds"

--- a/ansible/script/keystone.sh
+++ b/ansible/script/keystone.sh
@@ -183,7 +183,7 @@ install(){
     if [ "docker" == "$1" ]
     then
         docker pull opensdsio/opensds-authchecker:latest
-        docker run -d --privileged=true --net=host --name=opensds-authchecker opensdsio/opensds-authchecker:latest
+        docker run -d --privileged=true --restart=always --net=host --name=opensds-authchecker opensdsio/opensds-authchecker:latest
         docker cp "$TOP_DIR/../../conf/keystone.policy.json" opensds-authchecker:/etc/keystone/policy.json
         keystone_credentials
         wait_for_keystone


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR sets the restart policy to `always` when the SODA API, Controller, Dock and Auth projects are installed with `install_from` set to `container`. Auth is always installed as  a container but the rest of the projects are generally installed from `release` or `source`.  
With this change, if the containers for Api, controller, dock and auth get killed they will be restarted.

This PR also updates the etcd service installation as when `install_from=container`. The container configuration has been set using appropriate etcd environment variables and a docker volume is created and mapped to store etcd data. This etcd data is cleared only if the database purge is set to true by setting `database_purge=true` in the `group_vars/common.yml`. 
If it is set to `false` then the etcd data volume is not removed and on reinstall of SODA using containers the volume is still available and so is the data.

**Which issue(s) this PR fixes**:
Fixes #453 Possibly #279

**Test Report Added?**:
/kind TESTED

**Test Report**:

**Auth**
![container-auth-01](https://user-images.githubusercontent.com/19162717/115418521-2d20bd80-a217-11eb-95b2-102d54a219aa.png)

**Api**
![container-api-01](https://user-images.githubusercontent.com/19162717/115418555-33af3500-a217-11eb-8511-a32647c2adf7.png)

**Controller**
![container-controller-01](https://user-images.githubusercontent.com/19162717/115418541-314cdb00-a217-11eb-8885-b0a291e36327.png)

**Dock**
![container-dock-01](https://user-images.githubusercontent.com/19162717/115418567-3578f880-a217-11eb-8743-e66b59e3e408.png)


**Special notes for your reviewer**:
