### PR TITLE
Fixed broken bintray links in rabbitmq installation for Delfin

### DIFF
--- a/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
+++ b/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
@@ -23,7 +23,7 @@
 
 - name: Import RabbitMQ public key
   apt_key:
-    url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+    url: https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
     state: present
   become: yes
   when:
@@ -31,7 +31,7 @@
 
 - name: Add RabbitMQ official repo
   apt_repository: 
-    repo: deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main
+    repo: deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu {{ ansible_distribution_release }} main
     state: present
     filename: rabbitmq
   become: yes


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
This PR fixes the broken bintray links in rabbitmq installation as part of the Delfin installer.

**Which issue(s) this PR fixes**:
Fixes #456 

**Test Report Added?**:
/kind TESTED


**Test Report**:
This is tested with the GitHub Actions migration test.
The passed CI can be seen [here](https://github.com/anvithks/installer/runs/2501558327?check_suite_focus=true)

From the CI run
```
TASK [delfin-installer : Import RabbitMQ public key] ***************************
task path: /home/runner/work/installer/installer/ansible/roles/delfin-installer/scenarios/rabbitmq.yml:24
changed: [localhost] => {"changed": true, "failed": false}

TASK [delfin-installer : Add RabbitMQ official repo] ***************************
task path: /home/runner/work/installer/installer/ansible/roles/delfin-installer/scenarios/rabbitmq.yml:32
changed: [localhost] => {"changed": true, "failed": false, "repo": "deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu xenial main", "state": "present"}

TASK [delfin-installer : Import Erlang public key] *****************************
task path: /home/runner/work/installer/installer/ansible/roles/delfin-installer/scenarios/rabbitmq.yml:41
ok: [localhost] => {"changed": false, "failed": false}

TASK [delfin-installer : Add Erlang official repo] *****************************
task path: /home/runner/work/installer/installer/ansible/roles/delfin-installer/scenarios/rabbitmq.yml:49
changed: [localhost] => {"changed": true, "failed": false, "repo": "deb https://binaries.erlang-solutions.com/debian xenial contrib", "state": "present"}

TASK [delfin-installer : Install RabbitMQ package] *****************************
task path: /home/runner/work/installer/installer/ansible/roles/delfin-installer/scenarios/rabbitmq.yml:58
changed: [localhost] => (item=[u'apt-transport-https', u'rabbitmq-server']) => {"cache_update_time": 1620140516, "cache_updated": true, "changed": true, "failed": false, "item": ["apt-transport-https", "rabbitmq-server"], "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following NEW packages will be installed:\n  rabbitmq-server\n0 upgraded, 1 newly installed, 0 to remove and 289 not upgraded.\nNeed to get 4251 kB of archives.\nAfter this operation, 5243 kB of additional disk space will be used.\nGet:1 http://azure.archive.ubuntu.com/ubuntu xenial-updates/main amd64 rabbitmq-server all 3.5.7-1ubuntu0.16.04.4 [4251 kB]\nFetched 4251 kB in 0s (25.5 MB/s)\nSelecting previously unselected package rabbitmq-server.\r\n(Reading database ... \r(Reading database ... 5%\r(Reading database ... 10%\r(Reading database ... 15%\r(Reading database ... 20%\r(Reading database ... 25%\r(Reading database ... 30%\r(Reading database ... 35%\r(Reading database ... 40%\r(Reading database ... 45%\r(Reading database ... 50%\r(Reading database ... 55%\r(Reading database ... 60%\r(Reading database ... 65%\r(Reading database ... 70%\r(Reading database ... 75%\r(Reading database ... 80%\r(Reading database ... 85%\r(Reading database ... 90%\r(Reading database ... 95%\r(Reading database ... 100%\r(Reading database ... 222226 files and directories currently installed.)\r\nPreparing to unpack .../rabbitmq-server_3.5.7-1ubuntu0.16.04.4_all.deb ...\r\nUnpacking rabbitmq-server (3.5.7-1ubuntu0.16.04.4) ...\r\nProcessing triggers for man-db (2.7.5-1) ...\r\nProcessing triggers for ureadahead (0.100.0-19.1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.31) ...\r\nSetting up rabbitmq-server (3.5.7-1ubuntu0.16.04.4) ...\r\nAdding group `rabbitmq' (GID 125) ...\r\nsent invalidate(group) request, exiting\r\nsent invalidate(passwd) request, exiting\r\nsent invalidate(group) request, exiting\r\nsent invalidate(group) request, exiting\r\nsent invalidate(group) request, exiting\r\nDone.\r\nAdding system user `rabbitmq' (UID 119) ...\r\nsent invalidate(passwd) request, exiting\r\nsent invalidate(group) request, exiting\r\nAdding new user `rabbitmq' (UID 119) with group `rabbitmq' ...\r\nsent invalidate(passwd) request, exiting\r\nsent invalidate(group) request, exiting\r\nsent invalidate(passwd) request, exiting\r\nsent invalidate(group) request, exiting\r\nsent invalidate(passwd) request, exiting\r\nsent invalidate(group) request, exiting\r\nsent invalidate(passwd) request, exiting\r\nsent invalidate(group) request, exiting\r\nsent invalidate(passwd) request, exiting\r\nsent invalidate(group) request, exiting\r\nsent invalidate(passwd) request, exiting\r\nNot creating home directory `/var/lib/rabbitmq'.\r\nProcessing triggers for ureadahead (0.100.0-19.1) ...\r\nProcessing triggers for systemd (229-4ubuntu21.31) ...\r\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following NEW packages will be installed:", "  rabbitmq-server", "0 upgraded, 1 newly installed, 0 to remove and 289 not upgraded.", "Need to get 4251 kB of archives.", "After this operation, 5243 kB of additional disk space will be used.", "Get:1 http://azure.archive.ubuntu.com/ubuntu xenial-updates/main amd64 rabbitmq-server all 3.5.7-1ubuntu0.16.04.4 [4251 kB]", "Fetched 4251 kB in 0s (25.5 MB/s)", "Selecting previously unselected package rabbitmq-server.", "(Reading database ... ", "(Reading database ... 5%", "(Reading database ... 10%", "(Reading database ... 15%", "(Reading database ... 20%", "(Reading database ... 25%", "(Reading database ... 30%", "(Reading database ... 35%", "(Reading database ... 40%", "(Reading database ... 45%", "(Reading database ... 50%", "(Reading database ... 55%", "(Reading database ... 60%", "(Reading database ... 65%", "(Reading database ... 70%", "(Reading database ... 75%", "(Reading database ... 80%", "(Reading database ... 85%", "(Reading database ... 90%", "(Reading database ... 95%", "(Reading database ... 100%", "(Reading database ... 222226 files and directories currently installed.)", "Preparing to unpack .../rabbitmq-server_3.5.7-1ubuntu0.16.04.4_all.deb ...", "Unpacking rabbitmq-server (3.5.7-1ubuntu0.16.04.4) ...", "Processing triggers for man-db (2.7.5-1) ...", "Processing triggers for ureadahead (0.100.0-19.1) ...", "Processing triggers for systemd (229-4ubuntu21.31) ...", "Setting up rabbitmq-server (3.5.7-1ubuntu0.16.04.4) ...", "Adding group `rabbitmq' (GID 125) ...", "sent invalidate(group) request, exiting", "sent invalidate(passwd) request, exiting", "sent invalidate(group) request, exiting", "sent invalidate(group) request, exiting", "sent invalidate(group) request, exiting", "Done.", "Adding system user `rabbitmq' (UID 119) ...", "sent invalidate(passwd) request, exiting", "sent invalidate(group) request, exiting", "Adding new user `rabbitmq' (UID 119) with group `rabbitmq' ...", "sent invalidate(passwd) request, exiting", "sent invalidate(group) request, exiting", "sent invalidate(passwd) request, exiting", "sent invalidate(group) request, exiting", "sent invalidate(passwd) request, exiting", "sent invalidate(group) request, exiting", "sent invalidate(passwd) request, exiting", "sent invalidate(group) request, exiting", "sent invalidate(passwd) request, exiting", "sent invalidate(group) request, exiting", "sent invalidate(passwd) request, exiting", "Not creating home directory `/var/lib/rabbitmq'.", "Processing triggers for ureadahead (0.100.0-19.1) ...", "Processing triggers for systemd (229-4ubuntu21.31) ..."]}

TASK [delfin-installer : Start the RabbitMQ server] ****************************
task path: /home/runner/work/installer/installer/ansible/roles/delfin-installer/scenarios/rabbitmq.yml:72
ok: [localhost] => {"changed": false, "failed": false, "name": "rabbitmq-server", "state": "started", "status": {"ActiveEnterTimestamp": "Tue 2021-05-04 15:02:03 UTC", "ActiveEnterTimestampMonotonic": "290382473", "ActiveExitTimestamp": "Tue 2021-05-04 15:02:03 UTC", "ActiveExitTimestampMonotonic": "290558726", "ActiveState": "activating", "After": "network.target sysinit.target basic.target systemd-journald.socket system.slice", "AllowIsolate": "no", "AmbientCapabilities": "0", "AssertResult": "yes", "AssertTimestamp": "Tue 2021-05-04 15:02:00 UTC", "AssertTimestampMonotonic": "287455361", "Before": "multi-user.target shutdown.target", "BlockIOAccounting": "no", "BlockIOWeight": "18446744073709551615", "CPUAccounting": "no", "CPUQuotaPerSecUSec": "infinity", "CPUSchedulingPolicy": "0", "CPUSchedulingPriority": "0", "CPUSchedulingResetOnFork": "no", "CPUShares": "18446744073709551615", "CPUUsageNSec": "18446744073709551615", "CanIsolate": "no", "CanReload": "no", "CanStart": "yes", "CanStop": "yes", "CapabilityBoundingSet": "18446744073709551615", "ConditionResult": "yes", "ConditionTimestamp": "Tue 2021-05-04 15:02:00 UTC", "ConditionTimestampMonotonic": "287455360", "Conflicts": "shutdown.target", "ControlPID": "0", "DefaultDependencies": "yes", "Delegate": "no", "Description": "RabbitMQ Messaging Server", "DevicePolicy": "auto", "ExecMainCode": "1", "ExecMainExitTimestamp": "Tue 2021-05-04 15:02:03 UTC", "ExecMainExitTimestampMonotonic": "290558249", "ExecMainPID": "24110", "ExecMainStartTimestamp": "Tue 2021-05-04 15:02:00 UTC", "ExecMainStartTimestampMonotonic": "287456258", "ExecMainStatus": "1", "ExecStart": "{ path=/usr/sbin/rabbitmq-server ; argv[]=/usr/sbin/rabbitmq-server ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExecStartPost": "{ path=/usr/lib/rabbitmq/bin/rabbitmq-server-wait ; argv[]=/usr/lib/rabbitmq/bin/rabbitmq-server-wait ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }", "ExecStop": "{ path=/usr/sbin/rabbitmqctl ; argv[]=/usr/sbin/rabbitmqctl stop ; ignore_errors=no ; start_time=[n/a] ; stop_time=[Tue 2021-05-04 15:02:04 UTC] ; pid=24396 ; code=exited ; status=2 }", "FailureAction": "none", "FileDescriptorStoreMax": "0", "FragmentPath": "/lib/systemd/system/rabbitmq-server.service", "GuessMainPID": "yes", "IOScheduling": "0", "Id": "rabbitmq-server.service", "IgnoreOnIsolate": "no", "IgnoreSIGPIPE": "yes", "InactiveEnterTimestamp": "Tue 2021-05-04 15:02:04 UTC", "InactiveEnterTimestampMonotonic": "291432325", "InactiveExitTimestamp": "Tue 2021-05-04 15:02:04 UTC", "InactiveExitTimestampMonotonic": "291432465", "JobTimeoutAction": "none", "JobTimeoutUSec": "infinity", "KillMode": "control-group", "KillSignal": "15", "LimitAS": "18446744073709551615", "LimitASSoft": "18446744073709551615", "LimitCORE": "18446744073709551615", "LimitCORESoft": "0", "LimitCPU": "18446744073709551615", "LimitCPUSoft": "18446744073709551615", "LimitDATA": "18446744073709551615", "LimitDATASoft": "18446744073709551615", "LimitFSIZE": "18446744073709551615", "LimitFSIZESoft": "18446744073709551615", "LimitLOCKS": "18446744073709551615", "LimitLOCKSSoft": "18446744073709551615", "LimitMEMLOCK": "65536", "LimitMEMLOCKSoft": "65536", "LimitMSGQUEUE": "819200", "LimitMSGQUEUESoft": "819200", "LimitNICE": "0", "LimitNICESoft": "0", "LimitNOFILE": "65536", "LimitNOFILESoft": "65536", "LimitNPROC": "27798", "LimitNPROCSoft": "27798", "LimitRSS": "18446744073709551615", "LimitRSSSoft": "18446744073709551615", "LimitRTPRIO": "0", "LimitRTPRIOSoft": "0", "LimitRTTIME": "18446744073709551615", "LimitRTTIMESoft": "18446744073709551615", "LimitSIGPENDING": "27798", "LimitSIGPENDINGSoft": "27798", "LimitSTACK": "18446744073709551615", "LimitSTACKSoft": "8388608", "LoadState": "loaded", "MainPID": "0", "MemoryAccounting": "no", "MemoryCurrent": "18446744073709551615", "MemoryLimit": "18446744073709551615", "MountFlags": "0", "NFileDescriptorStore": "0", "Names": "rabbitmq-server.service", "NeedDaemonReload": "no", "Nice": "0", "NoNewPrivileges": "no", "NonBlocking": "no", "NotifyAccess": "none", "OOMScoreAdjust": "0", "OnFailureJobMode": "replace", "PermissionsStartOnly": "no", "PrivateDevices": "no", "PrivateNetwork": "no", "PrivateTmp": "no", "ProtectHome": "no", "ProtectSystem": "no", "RefuseManualStart": "no", "RefuseManualStop": "no", "RemainAfterExit": "no", "Requires": "system.slice sysinit.target", "Restart": "on-failure", "RestartUSec": "10s", "Result": "exit-code", "RootDirectoryStartOnly": "no", "RuntimeDirectoryMode": "0755", "RuntimeMaxUSec": "infinity", "SameProcessGroup": "no", "SecureBits": "0", "SendSIGHUP": "no", "SendSIGKILL": "yes", "Slice": "system.slice", "StandardError": "inherit", "StandardInput": "null", "StandardOutput": "journal", "StartLimitAction": "none", "StartLimitBurst": "5", "StartLimitInterval": "10000000", "StartupBlockIOWeight": "18446744073709551615", "StartupCPUShares": "18446744073709551615", "StateChangeTimestamp": "Tue 2021-05-04 15:02:04 UTC", "StateChangeTimestampMonotonic": "291432465", "StatusErrno": "0", "StopWhenUnneeded": "no", "SubState": "auto-restart", "SyslogFacility": "3", "SyslogIdentifier": "rabbitmq", "SyslogLevel": "6", "SyslogLevelPrefix": "yes", "SyslogPriority": "30", "SystemCallErrorNumber": "0", "TTYReset": "no", "TTYVHangup": "no", "TTYVTDisallocate": "no", "TasksAccounting": "no", "TasksCurrent": "18446744073709551615", "TasksMax": "18446744073709551615", "TimeoutStartUSec": "10min", "TimeoutStopUSec": "1min 30s", "TimerSlackNSec": "50000", "Transient": "no", "Type": "simple", "UMask": "0022", "UnitFilePreset": "enabled", "UnitFileState": "enabled", "User": "rabbitmq", "UtmpMode": "init", "WantedBy": "multi-user.target", "WatchdogTimestampMonotonic": "0", "WatchdogUSec": "0"}}
```
**Special notes for your reviewer**:
