### PR TITLE
Updated the RabbitMQ steps as per the official installer to fix installation issue on Ubuntu 18.04

### DIFF
--- a/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
+++ b/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
@@ -29,9 +29,34 @@
   when:
     - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
 
-- name: Add RabbitMQ official repo
+- name: Add Launchpad Erlang PPA key
+  apt_key:
+    keyserver: keyserver.ubuntu.com 
+    id: F77F1EDA57EBB1CC
+  become: yes
+  when:
+    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
+
+- name: Add PackageCloud RabbitMQ repository
+  apt_key:
+    url: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
+    state: present
+  become: yes
+  when:
+    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
+
+- name: Add RabbitMQ Erlang official repo
   apt_repository: 
     repo: deb http://ppa.launchpad.net/rabbitmq/rabbitmq-erlang/ubuntu {{ ansible_distribution_release }} main
+    state: present
+    filename: rabbitmq
+  become: yes
+  when:
+    - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false
+
+- name: Add RabbitMQ Server official repo
+  apt_repository: 
+    repo: deb https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu/ {{ ansible_distribution_release }} main
     state: present
     filename: rabbitmq
   become: yes


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
This PR fixes the issue of RabbitMQ installation failing on Ubuntu18.04.
After the dead bintray links were replaced in #457 the installation was successding on Ubuntu16.04 but failed on Ubuntu18.04.

Turns out the keys needed for `rabbitmq-erlang` and `rabbitmq-server` needed to be downloaded and set up with apt-key.

This PR adds those keys and also updates the links of the apt-repositories for the above.

**Which issue(s) this PR fixes**:

Fixes #456 

**Test Report Added?**:
/kind TESTED


**Test Report**:
[This](https://github.com/anvithks/installer/actions/runs/819964441) is the workflow run for the PR where this was tested using the Github actions.
**Special notes for your reviewer**:
