### PR TITLE
Added flag to enable and disable storage service plans

### DIFF
--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -78,4 +78,8 @@ delfin_release_version: v1.2.1
 #################
 # URLs, Environment Variables, IP addresses and Ports list
 soda_delfin_url: "http://{{ host_ip }}:8190"
+
+# Inform the SODA Dashboard whether SODA Multicloud UI should support only service plans or backends
+# If true, user will have access only to the service plans for bucket management and not to the cloud backends
+# If false, user will have access to register cloud backends and access the cloud backends for bucket management.
 enable_storage_service_plans: false

--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -78,3 +78,4 @@ delfin_release_version: v1.2.1
 #################
 # URLs, Environment Variables, IP addresses and Ports list
 soda_delfin_url: "http://{{ host_ip }}:8190"
+enable_storage_service_plans: false

--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -79,6 +79,7 @@ delfin_release_version: v1.2.1
 # URLs, Environment Variables, IP addresses and Ports list
 soda_delfin_url: "http://{{ host_ip }}:8190"
 
+# ToDo: Use this variable across the SODA Projects. Currently using this only for the SODA Dashboard.
 # Inform the SODA Dashboard whether SODA Multicloud UI should support only service plans or backends
 # If true, user will have access only to the service plans for bucket management and not to the cloud backends
 # If false, user will have access to register cloud backends and access the cloud backends for bucket management.

--- a/ansible/roles/dashboard-installer/scenarios/container.yml
+++ b/ansible/roles/dashboard-installer/scenarios/container.yml
@@ -36,6 +36,7 @@
       SODA_PROMETHEUS_PORT: "{{ prometheus_port }}"
       SODA_ALERTMANAGER_PORT: "{{ alertmanager_port }}"
       SODA_GRAFANA_PORT: "{{ grafana_port }}"
+      STORAGE_SERVICE_PLAN_ENABLED: "{{ enable_storage_service_plans }}"
       SODA_ALERTMANAGER_URL: "http://{{ host_ip }}:{{ alertmanager_port }}"
   when: gelato_ha != true
   
@@ -58,5 +59,6 @@
       SODA_PROMETHEUS_PORT: "{{ prometheus_port }}"
       SODA_ALERTMANAGER_PORT: "{{ alertmanager_port }}"
       SODA_GRAFANA_PORT: "{{ grafana_port }}"
+      STORAGE_SERVICE_PLAN_ENABLED: "{{ enable_storage_service_plans }}"
       SODA_ALERTMANAGER_URL: "http://{{ host_ip }}:{{ alertmanager_port }}"      
   when: gelato_ha == true


### PR DESCRIPTION
**What type of PR is this?**
/kind new feature

**What this PR does / why we need it**:
This PR adds the `enable_storage_service_plans` flag to allow the user to inform the client (SODA Dashboard ) whether the SODA multicloud  should be displayed with Storage Service plans or backends from the dashboard.

**Which issue(s) this PR fixes**:
Fixes #463 

**Test Report Added?**:
/kind TESTED


**Test Report**:

**Special notes for your reviewer**:
