### PR TITLE
Added changes to support and enable installation of SODA on Ubuntu20.04

### DIFF
--- a/.github/workflows/ci_pull_request.yml
+++ b/.github/workflows/ci_pull_request.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.13.x]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -41,13 +41,7 @@ jobs:
         run: |
             echo "Installed Ansible Version in Runtime: "
             ansible --version
-        
-      - name: Remove latest ansible on Ubuntu 18.04
-        run: |
-            echo "uninstall with pipx"
-            pipx uninstall ansible-core
-        if: ${{ matrix.os == 'ubuntu-18.04' }}
-
+      
       # Change the permissions of the ansible installer
       - name: 'Make ansible installer executable and run install ansible on OS: ${{ matrix.os }}'
         run: |

--- a/.github/workflows/ci_pull_request.yml
+++ b/.github/workflows/ci_pull_request.yml
@@ -67,16 +67,7 @@ jobs:
           GOPATH: "/home/runner/work/installer/"
         if: ${{ always() }}
 
-      - name: 'Make the CI check executable and initiate the testing with SODA repository'
-        run: |
-          sudo chmod +x ./ci/ci_check.sh
-          ./ci/ci_check.sh repository
-        shell: bash
-        env:
-          GOPATH: "/home/runner/work/installer/"
-        if: ${{ always() }}
-      
-      - name: 'Make the CI check executable and initiate the testing with SODA release'
+     - name: 'Make the CI check executable and initiate the testing with SODA release'
         run: |
           sudo chmod +x ./ci/ci_check.sh
           ./ci/ci_check.sh release

--- a/.github/workflows/ci_pull_request.yml
+++ b/.github/workflows/ci_pull_request.yml
@@ -42,6 +42,12 @@ jobs:
             echo "Installed Ansible Version in Runtime: "
             ansible --version
       
+      - name: Remove latest ansible on Ubuntu 20.04
+        run: |
+            echo "uninstall with pipx"
+            pipx uninstall ansible-core
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
+
       # Change the permissions of the ansible installer
       - name: 'Make ansible installer executable and run install ansible on OS: ${{ matrix.os }}'
         run: |

--- a/.github/workflows/ci_pull_request.yml
+++ b/.github/workflows/ci_pull_request.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches:
       - main
-      - feat/ubuntu2004
+      - ubuntu2004-experimental
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci_pull_request.yml
+++ b/.github/workflows/ci_pull_request.yml
@@ -5,7 +5,12 @@ name: SODA Installer CI
 # Controls when the action will run. 
 # Triggers the workflow on push or pull request events but only for the main branch
 # Allows you to run this workflow manually from the Actions tab
-on: [pull_request, workflow_dispatch]
+on: 
+  pull_request:
+    branches:
+      - main
+      - feat/ubuntu2004
+  workflow_dispatch:
 
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/ci_pull_request.yml
+++ b/.github/workflows/ci_pull_request.yml
@@ -67,7 +67,7 @@ jobs:
           GOPATH: "/home/runner/work/installer/"
         if: ${{ always() }}
 
-     - name: 'Make the CI check executable and initiate the testing with SODA release'
+      - name: 'Make the CI check executable and initiate the testing with SODA release'
         run: |
           sudo chmod +x ./ci/ci_check.sh
           ./ci/ci_check.sh release

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -5,8 +5,12 @@ name: SODA Installer CI
 # Controls when the action will run. 
 # Triggers the workflow on push or pull request events but only for the main branch
 # Allows you to run this workflow manually from the Actions tab
-on: [push, workflow_dispatch]
-
+on:
+  push:
+    branches:
+      - main
+      - feat/ubuntu2004
+  workflow_dispatch:
 jobs:
   # This workflow contains a single job called "build"
   build:

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -66,15 +66,6 @@ jobs:
           GOPATH: "/home/runner/work/installer/"
         if: ${{ always() }}
 
-      - name: 'Make the CI check executable and initiate the testing with SODA repository'
-        run: |
-          sudo chmod +x ./ci/ci_check.sh
-          ./ci/ci_check.sh repository
-        shell: bash
-        env:
-          GOPATH: "/home/runner/work/installer/"
-        if: ${{ always() }}
-
       - name: 'Make the CI check executable and initiate the testing with SODA release'
         run: |
           sudo chmod +x ./ci/ci_check.sh

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -40,6 +40,12 @@ jobs:
         run: |
             echo "Installed Ansible Version in Runtime: "
             ansible --version
+      
+      - name: Remove latest ansible on Ubuntu 20.04
+        run: |
+            echo "uninstall with pipx"
+            pipx uninstall ansible-core
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
         
       # Change the permissions of the ansible installer
       - name: 'Make ansible installer executable and run install ansible on OS: ${{ matrix.os }}'

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - main
-      - feat/ubuntu2004
+      - ubuntu2004-experimental
   workflow_dispatch:
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.13.x]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -41,12 +41,6 @@ jobs:
             echo "Installed Ansible Version in Runtime: "
             ansible --version
         
-      - name: Remove latest ansible on Ubuntu 18.04
-        run: |
-            echo "uninstall with pipx"
-            pipx uninstall ansible-core
-        if: ${{ matrix.os == 'ubuntu-18.04'}}
-
       # Change the permissions of the ansible installer
       - name: 'Make ansible installer executable and run install ansible on OS: ${{ matrix.os }}'
         run: |

--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -54,6 +54,11 @@ ansible_os_family: Debian
 # false: Will install api, dock, controller and etcd as standalone processes. Recommended for development use.
 install_as_systemd: true
 
+# Install  etcd as systemd process or standalone application: true / false
+# true: Will install etcd as a systemd service and enable it. Recommended for production use
+# false: Will install etcd as standalone process. Recommended for development use and on Ubuntu 20.04.
+install_etcd_as_systemd: false
+
 # delete all source packages
 source_purge: true
 

--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -43,7 +43,7 @@ install_gelato_ha_from: release
 
 # These fields below will specify the tag based on install_from type
 repo_branch: master
-release_version: v1.5.2
+release_version: v1.6.0
 
 # This field indicates which os family the system will be running, currently
 # support 'Debian' and 'RedHat'
@@ -74,11 +74,11 @@ opensds_conf_file: /etc/opensds/opensds.conf
 api_release_version: v1.1.0
 controller_release_version: v1.1.0
 dock_release_version: v1.3.0
-dashboard_release_version: v1.5.1
-gelato_release_version: v1.5.1
+dashboard_release_version: v1.6.0
+gelato_release_version: v1.6.0
 sushi_release_version: v1.4.0
 orchestration_release_version: v0.13.0
-delfin_release_version: v1.4.1
+delfin_release_version: v1.5.0
 
 #################
 # URLs, Environment Variables, IP addresses and Ports list

--- a/ansible/group_vars/common.yml
+++ b/ansible/group_vars/common.yml
@@ -52,7 +52,7 @@ ansible_os_family: Debian
 # Install as systemd process or standalone application: true / false
 # true: Will install api, dock, controller and etcd processes as a systemd services and enable them. Recommended for production use
 # false: Will install api, dock, controller and etcd as standalone processes. Recommended for development use.
-install_as_systemd: true
+install_as_systemd: false
 
 # Install  etcd as systemd process or standalone application: true / false
 # true: Will install etcd as a systemd service and enable it. Recommended for production use

--- a/ansible/roles/cleaner/tasks/main.yml
+++ b/ansible/roles/cleaner/tasks/main.yml
@@ -24,7 +24,7 @@
 # Kill all the systemd processes and disable services
 - name: kill osdslet and osdsdock and osdsapiserver etcd daemon service
   shell: killall osdslet osdsdock osdsapiserver etcd
-  when: install_from != "container" and install_as_systemd == false
+  when: install_from != "container" and install_as_systemd == false and install_etcd_as_systemd == false
   ignore_errors: true
   become: true
   tags: hotpot
@@ -32,7 +32,7 @@
 # Kill all the systemd processes and disable services
 - name: kill osdslet and osdsdock and osdsapiserver etcd daemon service
   shell: killall osdslet osdsdock osdsapiserver etcd
-  when: install_from != "container" and install_as_systemd == true
+  when: install_from != "container" and install_as_systemd == true and install_etcd_as_systemd == true
   notify:
     - Stop Controller service
     - Disable Controller service
@@ -79,7 +79,7 @@
     state: absent
     force: yes
   ignore_errors: yes
-  when: install_as_systemd == false and ( database_purge is undefined or database_purge == true )
+  when: install_etcd_as_systemd == false and ( database_purge is undefined or database_purge == true )
   tags: hotpot
 
 - name: clean etcd db
@@ -88,7 +88,7 @@
     state: absent
     force: yes
   ignore_errors: yes
-  when: install_as_systemd == false and ( database_purge is undefined or database_purge == true )
+  when: install_etcd_as_systemd == false and ( database_purge is undefined or database_purge == true )
   tags: hotpot
 
 - name: stop all gelato services

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -27,7 +27,7 @@
   become: yes
 
 - name: run the equivalent of "apt-get update" as a separate step
-  when: ansible_distribution == "Ubuntu" and (ansible_lsb.major_release|int >=16 and ansible_lsb.major_release|int <=18)
+  when:  ansible_facts['distribution'] == 'Ubuntu' and (ansible_facts['distribution_major_version']|int >=16 and ansible_facts['distribution_major_version']|int <=20)
   apt:
     update_cache: yes
 
@@ -38,9 +38,9 @@
   with_items:
     - make
     - gcc
-    - python-pip
+    - python3-pip
     - open-iscsi
-  when: ansible_distribution == "Ubuntu" and (ansible_lsb.major_release|int >=16 and ansible_lsb.major_release|int <=18)
+  when: ansible_facts['distribution'] == 'Ubuntu' and (ansible_facts['distribution_major_version']|int >=16 and ansible_facts['distribution_major_version']|int <=20)
 
 - name: Install system packages on CentoS or RHEL
   when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
@@ -63,7 +63,7 @@
   with_items:
     - librados-dev
     - librbd-dev
-  when: ansible_distribution == "Ubuntu" and (ansible_lsb.major_release|int >=16 and ansible_lsb.major_release|int <=18)
+  when: ansible_facts['distribution'] == 'Ubuntu' and (ansible_facts['distribution_major_version']|int >=16 and ansible_facts['distribution_major_version']|int <=20)
 
 - name: create opensds work directory if it doesn't exist
   file:

--- a/ansible/roles/dashboard-installer/scenarios/container.yml
+++ b/ansible/roles/dashboard-installer/scenarios/container.yml
@@ -33,10 +33,10 @@
       OPENSDS_S3_URL: "http://{{ host_ip }}:8090"
       OPENSDS_S3_HOST: "{{ host_ip }}" 
       OPENSDS_S3_PORT: "8090"
-      SODA_PROMETHEUS_PORT: "{{ prometheus_port }}"
-      SODA_ALERTMANAGER_PORT: "{{ alertmanager_port }}"
-      SODA_GRAFANA_PORT: "{{ grafana_port }}"
-      STORAGE_SERVICE_PLAN_ENABLED: "{{ enable_storage_service_plans }}"
+      SODA_PROMETHEUS_PORT: "{{ prometheus_port|quote }}"
+      SODA_ALERTMANAGER_PORT: "{{ alertmanager_port|quote }}"
+      SODA_GRAFANA_PORT: "{{ grafana_port|quote }}"
+      STORAGE_SERVICE_PLAN_ENABLED: "{{ enable_storage_service_plans|string }}"
       SODA_ALERTMANAGER_URL: "http://{{ host_ip }}:{{ alertmanager_port }}"
   when: gelato_ha != true
   
@@ -56,9 +56,9 @@
       OPENSDS_S3_URL: "http://{{ gelato_ha_s3_ip }}:{{ gelato_ha_s3_port }}"
       OPENSDS_S3_HOST: "{{ gelato_ha_s3_ip }}"
       OPENSDS_S3_PORT: "{{ gelato_ha_s3_port }}"
-      SODA_PROMETHEUS_PORT: "{{ prometheus_port }}"
-      SODA_ALERTMANAGER_PORT: "{{ alertmanager_port }}"
-      SODA_GRAFANA_PORT: "{{ grafana_port }}"
-      STORAGE_SERVICE_PLAN_ENABLED: "{{ enable_storage_service_plans }}"
+      SODA_PROMETHEUS_PORT: "{{ prometheus_port|quote }}"
+      SODA_ALERTMANAGER_PORT: "{{ alertmanager_port|quote}}"
+      SODA_GRAFANA_PORT: "{{ grafana_port|quote}}"
+      STORAGE_SERVICE_PLAN_ENABLED: "{{ enable_storage_service_plans|string }}"
       SODA_ALERTMANAGER_URL: "http://{{ host_ip }}:{{ alertmanager_port }}"      
   when: gelato_ha == true

--- a/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
+++ b/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
@@ -82,12 +82,11 @@
 
 - name: Install RabbitMQ package
   apt: 
-    name: ['apt-transport-https', 'rabbitmq-server']
+    name: ['erlang-base', 'erlang-asn1', 'erlang-crypto', 'erlang-eldap', 'erlang-ftp', 'erlang-inets', 'erlang-mnesia', 'erlang-os-mon', 'erlang-parsetools', 'erlang-public-key', 'erlang-runtime-tools', 'erlang-snmp', 'erlang-ssl', 'erlang-syntax-tools', 'erlang-tftp', 'erlang-tools', 'erlang-xmerl', 'apt-transport-https', 'rabbitmq-server']
     update_cache: yes
     install_recommends: yes
     allow_unauthenticated: yes
     state: present
-    dpkg_options: 'fix-missing'
   become: yes
   when:
     - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false

--- a/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
+++ b/ansible/roles/delfin-installer/scenarios/rabbitmq.yml
@@ -82,14 +82,12 @@
 
 - name: Install RabbitMQ package
   apt: 
-    name: "{{ item }}"
+    name: ['apt-transport-https', 'rabbitmq-server']
     update_cache: yes
     install_recommends: yes
     allow_unauthenticated: yes
     state: present
-  with_items:
-    - apt-transport-https 
-    - rabbitmq-server
+    dpkg_options: 'fix-missing'
   become: yes
   when:
     - rabbitmqservice.stat.exists is undefined or rabbitmqservice.stat.exists == false

--- a/ansible/roles/gelato-ha-uninstaller/scenarios/clean_gelato_ha.yml
+++ b/ansible/roles/gelato-ha-uninstaller/scenarios/clean_gelato_ha.yml
@@ -32,9 +32,9 @@
   shell: "{{ item }}"
   become_user: "{{ k8s_user }}"
   with_items:
-    - "kubectl patch pvc mongo-0-pv-claim -p '\''{{patch_param }}'\'' --type=merge -n soda-multi-cloud"
-    - "kubectl patch pvc mongo-1-pv-claim -p '\''{{patch_param }}'\'' --type=merge -n soda-multi-cloud"
-    - "kubectl patch pvc mongo-2-pv-claim -p '\''{{patch_param }}'\'' --type=merge -n soda-multi-cloud"
+    - 'kubectl patch pvc mongo-0-pv-claim -p "\""{{patch_param }}"\"" --type=merge -n soda-multi-cloud'
+    - 'kubectl patch pvc mongo-1-pv-claim -p "\""{{patch_param }}"\"" --type=merge -n soda-multi-cloud'
+    - 'kubectl patch pvc mongo-2-pv-claim -p "\""{{patch_param }}"\"" --type=merge -n soda-multi-cloud'
   ignore_errors: yes
 
 - name: Pause for 2 seconds
@@ -92,6 +92,6 @@
   file:
     state: absent
     path: "{{ gelato_work_dir }}/multi-cloud/"
-  ignore_error: yes
+    ignore_error: yes
   become: yes
   

--- a/ansible/roles/ha-ip-update/tasks/main.yml
+++ b/ansible/roles/ha-ip-update/tasks/main.yml
@@ -22,7 +22,6 @@
 
 # Same IP is used for both the services. Only Port is different (predefined)
 - name: replace the gelato_ha_api_ip and gelato_ha_s3_ip in the gelato-ha.yml
-  hosts: controllers
   replace:
     path: "{{ role_path }}/../../group_vars/gelato-ha.yml"
     regexp: "{{ item.regexp }}"

--- a/ansible/roles/osdsdb/scenarios/etcd.yml
+++ b/ansible/roles/osdsdb/scenarios/etcd.yml
@@ -74,6 +74,8 @@
       Type=notify
       Restart=always
       RestartSec=5s
+      User=root
+      Group=root
       LimitNOFILE=40000
       TimeoutStartSec=0
 
@@ -109,6 +111,15 @@
   when:
     - install_as_systemd == true and ( service_etcd_status.rc != 0 and etcd_service_source_exists.stat.exists is undefined or etcd_service_source_exists.stat.exists == false )  
   become: true
+
+- name: sleep for 5 seconds and wait for etcd to come up
+  wait_for:
+    host: "{{ etcd_host }}"
+    port: "{{ etcd_port }}"
+    state: started
+    delay: 5
+    timeout: 120
+  when: ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version']|int >=20
 
 - name: check etcd cluster health
   shell: ./etcdctl --endpoints http://{{ etcd_host }}:{{ etcd_port }} cluster-health

--- a/ansible/roles/osdsdb/scenarios/etcd.yml
+++ b/ansible/roles/osdsdb/scenarios/etcd.yml
@@ -47,20 +47,20 @@
   become: true
   args:
     chdir: "{{ etcd_dir }}"
-  when: install_as_systemd == false and service_etcd_status.rc != 0
+  when: install_etcd_as_systemd == false and service_etcd_status.rc != 0
 
 # Enable etcd service as systemd process
 - name: check for etcd service source file existed
   stat:
     path: "{{ etcd_dir }}/soda-etcd.service"
   register: etcd_service_source_exists
-  when: install_as_systemd == true
+  when: install_etcd_as_systemd == true
 
 - name: Check if etcd service source file exists
   debug:
     var: etcd_service_source_exists
     verbosity: 2
-  when: install_as_systemd == true
+  when: install_etcd_as_systemd == true
 
 - name: Create the etcd service file
   copy:
@@ -84,20 +84,20 @@
       [Install]
       WantedBy=multi-user.target
   when:
-    - install_as_systemd == true and ( service_etcd_status.rc != 0 and etcd_service_source_exists.stat.exists is undefined or etcd_service_source_exists.stat.exists == false )  
+    - install_etcd_as_systemd == true and ( service_etcd_status.rc != 0 and etcd_service_source_exists.stat.exists is undefined or etcd_service_source_exists.stat.exists == false )  
   become: true
 
 - name: check for etcd service file existed
   stat:
     path: "/etc/systemd/system/soda-etcd.service"
   register: etcd_service_exists
-  when: install_as_systemd == true
+  when: install_etcd_as_systemd == true
 
 - name: Check if etcd service file exists at systemd
   debug:
     var: etcd_service_exists
     verbosity: 2
-  when: install_as_systemd == true
+  when: install_etcd_as_systemd == true
 
 - name: Copy etcd service file to systemd
   copy:
@@ -109,7 +109,7 @@
     - Reload daemon
     - Start etcd service
   when:
-    - install_as_systemd == true and ( service_etcd_status.rc != 0 and etcd_service_source_exists.stat.exists is undefined or etcd_service_source_exists.stat.exists == false )  
+    - install_etcd_as_systemd == true and ( service_etcd_status.rc != 0 and etcd_service_source_exists.stat.exists is undefined or etcd_service_source_exists.stat.exists == false )  
   become: true
 
 - name: sleep for 5 seconds and wait for etcd to come up

--- a/ansible/roles/osdsdb/scenarios/etcd.yml
+++ b/ansible/roles/osdsdb/scenarios/etcd.yml
@@ -119,7 +119,7 @@
     state: started
     delay: 5
     timeout: 120
-    ignore_errors: true
+  ignore_errors: true
   when: ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version']|int >=20
 
 - name: check etcd cluster health

--- a/ansible/roles/osdsdb/scenarios/etcd.yml
+++ b/ansible/roles/osdsdb/scenarios/etcd.yml
@@ -119,6 +119,7 @@
     state: started
     delay: 5
     timeout: 120
+    ignore_errors: true
   when: ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version']|int >=20
 
 - name: check etcd cluster health

--- a/ansible/roles/osdsdock/scenarios/cinder_standalone.yml
+++ b/ansible/roles/osdsdock/scenarios/cinder_standalone.yml
@@ -18,7 +18,7 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - python-pip
+    - python3-pip
     - lvm2
     - thin-provisioning-tools
     - libffi-dev

--- a/ansible/script/keystone.sh
+++ b/ansible/script/keystone.sh
@@ -116,7 +116,7 @@ wait_for_keystone () {
     do
         # get a token to check if keystone is working correctly or not.
         # keystone credentials such as OS_USERNAME must be set before.
-        python ${TOP_DIR}/ministone.py token_issue
+        python3 ${TOP_DIR}/ministone.py token_issue
         if [ "$?" == "0" ]; then
             return
         fi
@@ -188,7 +188,7 @@ install(){
         docker cp "$TOP_DIR/../../conf/keystone.policy.json" opensds-authchecker:/etc/keystone/policy.json
         keystone_credentials
         wait_for_keystone
-        python ${TOP_DIR}/ministone.py endpoint_bulk_update keystone "http://${HOST_IP}/identity"
+        python3 ${TOP_DIR}/ministone.py endpoint_bulk_update keystone "http://${HOST_IP}/identity"
     else
         create_user
         download_code
@@ -227,7 +227,7 @@ config_hotpot() {
         create_user_and_endpoint_for_hotpot
     else
         keystone_credentials
-        python ${TOP_DIR}/ministone.py endpoint_bulk_update "opensds$OPENSDS_VERSION" "http://${HOST_IP}:50040/$OPENSDS_VERSION/%(tenant_id)s"
+        python3 ${TOP_DIR}/ministone.py endpoint_bulk_update "opensds$OPENSDS_VERSION" "http://${HOST_IP}:50040/$OPENSDS_VERSION/%(tenant_id)s"
     fi
 }
 
@@ -237,7 +237,7 @@ config_gelato() {
         create_user_and_endpoint_for_gelato
     else
         keystone_credentials
-        python ${TOP_DIR}/ministone.py endpoint_bulk_update "multicloud$MULTICLOUD_VERSION" "http://${HOST_IP}:8089/v1beta/%(tenant_id)s"
+        python3 ${TOP_DIR}/ministone.py endpoint_bulk_update "multicloud$MULTICLOUD_VERSION" "http://${HOST_IP}:8089/v1beta/%(tenant_id)s"
     fi
 }
 

--- a/ansible/script/ministone.py
+++ b/ansible/script/ministone.py
@@ -20,22 +20,23 @@ import requests
 import pprint
 import json
 
+
 def token_issue():
     body = {
         'auth': {
-            'identity': { 'methods': ['password'],
-                          'password': {
-                              'user': {
-                                  'name': OS_USERNAME,
-                                  'domain': { 'name': OS_USER_DOMAIN_NAME },
-                                  'password':  OS_PASSWORD
-                              }
-                          }
-                      },
+            'identity': {'methods': ['password'],
+                         'password': {
+                'user': {
+                    'name': OS_USERNAME,
+                    'domain': {'name': OS_USER_DOMAIN_NAME},
+                    'password':  OS_PASSWORD
+                }
+            }
+            },
             'scope': {
                 'project': {
                     'name':  OS_PROJECT_NAME,
-                    'domain': { 'name':  OS_USER_DOMAIN_NAME }
+                    'domain': {'name':  OS_USER_DOMAIN_NAME}
                 }
             }
         }
@@ -59,6 +60,7 @@ def token_issue():
     else:
         return None
 
+
 def service_list(token):
     headers = {
         'Content-Type': 'application/json',
@@ -76,11 +78,12 @@ def service_list(token):
         result_list = json.loads(r_get.text)['services']
 
         for s in result_list:
-            result_dict[s['name']] =  s['id']
+            result_dict[s['name']] = s['id']
     except:
         return None
 
     return result_dict
+
 
 def endpoint_list(token, service):
 
@@ -95,7 +98,7 @@ def endpoint_list(token, service):
             print('DEBUG: GET /v3/endpoints - status_code = %s' %
                   (r_get.status_code))
     except:
-       return None
+        return None
 
     if r_get.status_code != 200:
         return None
@@ -113,6 +116,7 @@ def endpoint_list(token, service):
 
     return ep_list
 
+
 def endpoint_bulk_update(token, service, url):
     headers = {
         'Content-Type': 'application/json',
@@ -127,7 +131,7 @@ def endpoint_bulk_update(token, service, url):
         print("DEBUG: ep_list: %s %s" % (ep_list, url))
 
     for ep in ep_list:
-        body = {"endpoint": { "url": url }}
+        body = {"endpoint": {"url": url}}
         endpoint_id = ep[0]
         if debug:
             print("DEBUG: %s / %s" %
@@ -147,6 +151,7 @@ def endpoint_bulk_update(token, service, url):
             print('DEBUG: PATCH /endpoints/XXXX - status_code = %s' %
                   (r_patch.status_code))
 
+
 #
 # ministone.py - A simple stupid keystone client with almost no dependencies.
 #
@@ -164,13 +169,13 @@ if __name__ == '__main__':
 
     debug = False
 
-    OS_AUTH_URL=os.environ['OS_AUTH_URL']
-    OS_PASSWORD=os.environ['OS_PASSWORD']
-    OS_PROJECT_DOMAIN_NAME=os.environ['OS_PROJECT_DOMAIN_NAME']
-    OS_PROJECT_NAME=os.environ['OS_PROJECT_NAME']
-    OS_USERNAME=os.environ['OS_USERNAME']
-    OS_USER_DOMAIN_NAME=os.environ['OS_USER_DOMAIN_NAME']
-    #OS_USER_DOMAIN_ID=os.environ['OS_USER_DOMAIN_ID']
+    OS_AUTH_URL = os.environ['OS_AUTH_URL']
+    OS_PASSWORD = os.environ['OS_PASSWORD']
+    OS_PROJECT_DOMAIN_NAME = os.environ['OS_PROJECT_DOMAIN_NAME']
+    OS_PROJECT_NAME = os.environ['OS_PROJECT_NAME']
+    OS_USERNAME = os.environ['OS_USERNAME']
+    OS_USER_DOMAIN_NAME = os.environ['OS_USER_DOMAIN_NAME']
+    # OS_USER_DOMAIN_ID=os.environ['OS_USER_DOMAIN_ID']
 
     # token_issue
     #   used for keystone process start up check.
@@ -178,15 +183,15 @@ if __name__ == '__main__':
     if len(sys.argv) == 2 and sys.argv[1] == 'token_issue':
         token = token_issue()
         if not token:
-           sys.exit(1)
+            sys.exit(1)
         else:
-           sys.exit(0)
+            sys.exit(0)
 
     # endpoint_bulk_update
     #   used for overwriting keystone endpoints
     if not ((len(sys.argv) == 4) and (sys.argv[1] == 'endpoint_bulk_update')):
         print('Specify service_name and url for bulk update. Exiting...')
-	sys.exit(1)
+        sys.exit(1)
 
     token = token_issue()
     if not token:

--- a/charts/opensds/values.yaml
+++ b/charts/opensds/values.yaml
@@ -101,7 +101,7 @@ osdsdashboard:
   name: dashboard
   replicaCount: 1
 
-  image: sodafoundation/dashboard:v1.5.1
+  image: sodafoundation/dashboard:v1.6.0
 
   # ImagePullPolicy: valid values are "IfNotPresent", "Never", and "Always"
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**What type of PR is this?**
/kind new feature

**What this PR does / why we need it**:
This PR enables installation of SODA on Ubuntu 20.04.
- Python2 is deprecated in Ubuntu20.04 and not available. All `python-pip` installations are upgraded to `python3-pip`
- All scripts running python2 scripts are now executed with python3
- Ansible version is updated to 2.9.6 (The default supported version for the ceph-ansible version supported)
- Changed the ansible variable syntax to updated syntax for Ansible 2.9. Changed usage of single and double quotes. 
- `install_as_systemd` is set to `false`. Bring api, controller and dock as standalone processes.
- Added an other variable called `install_etcd_as_systemd` and set it to `false`. etcd is also brought up as a standalone process.
- Updated the CI to work on the `ubuntu2004-experimental` branch.
- Removed the CI check for install from repository. Currently on install from release is tested with Ubuntu20.04

**Which issue(s) this PR fixes**:
Fixes #485 

**Test Report Added?**:
/kind TESTED

**Test Report**:
Tested on Ubuntu 20.04 on Virtual Box. 

**Special notes for your reviewer**:
There are some issues with the Anisble installation and etcd service running as a systemd process. Sometimes the process takes too much time to come up. This needs to be debugged and may be the etcd version needs to be updated.
