### PR TITLE
Fix setuptools version for install failure

### DIFF
--- a/ansible/install_dependencies.sh
+++ b/ansible/install_dependencies.sh
@@ -18,9 +18,15 @@ sudo apt-get update
 
 # Install python dependencies
 echo Installing Python dependencies
-sudo apt-get install -y python3-distutils
-sudo apt-get install -y python3-pip
-python3 -m pip install -U pip setuptools
+sudo apt-get install -y python3-distutils python3-testresources python3-pip
+python3 -m pip install -U pip
+
+# Update setuptool version if it is higher than 65
+ver=$(python3 -m pip show setuptools | awk '/^Version: / {sub("^Version: ", ""); print}' | cut -d. -f1)
+if [ "$ver" -gt 65 ]; then
+    echo Downgrade setuptools version to 65
+    python3 -m pip install setuptools==65.0.0
+fi
 
 # Install ansible if not present
 if [ "`which ansible`" != ""  ]; then


### PR DESCRIPTION
This PR is to ensure installed setuptools version, which is compatible with other modules of the project.
If setuptools version is higher than 65, downgrade it to 65
 
**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
Latest version of Python3 module `setuptools` is not compatible pip module and causes install failure when pip is used

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #510 

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED
> /kind NOT-TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
