### PR TITLE
Fixes install_dependencies for delfin installation in centos

### DIFF
--- a/ansible/install_dependencies.sh
+++ b/ansible/install_dependencies.sh
@@ -2,7 +2,7 @@
 
 # Install dependencies
 echo Installing dependencies
-sudo apt-get install -y make curl wget libltdl7 libseccomp2 libffi-dev gawk apt-transport-https ca-certificates curl gnupg gnupg-agent lsb-release software-properties-common sshpass pv
+sudo yum install -y make curl wget libltdl7 libseccomp2 libffi-dev gawk apt-transport-https ca-certificates curl gnupg gnupg-agent lsb-release software-properties-common sshpass pv
 
 echo Enabling docker repository
 sudo mkdir -p /etc/apt/keyrings
@@ -14,19 +14,13 @@ echo \
 
 # Update local repositories
 echo Updating local repositories
-sudo apt-get update
+sudo yum update
 
 # Install python dependencies
 echo Installing Python dependencies
-sudo apt-get install -y python3-distutils python3-testresources python3-pip
-python3 -m pip install -U pip
-
-# Update setuptool version if it is higher than 65
-ver=$(python3 -m pip show setuptools | awk '/^Version: / {sub("^Version: ", ""); print}' | cut -d. -f1)
-if [ "$ver" -gt 65 ]; then
-    echo Downgrade setuptools version to 65
-    python3 -m pip install setuptools==65.0.0
-fi
+sudo yum install -y python3-distutils
+sudo yum install -y python3-pip
+python3 -m pip install -U pip setuptools==65.0.0
 
 # Install ansible if not present
 if [ "`which ansible`" != ""  ]; then
@@ -41,7 +35,7 @@ if [ "`which docker`" != ""  ]; then
     echo Docker already installed, skipping.
 else
     echo Installing docker
-    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+    sudo yum install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
     sudo adduser $USER vboxsf
 fi
 

--- a/ansible/install_dependencies.sh
+++ b/ansible/install_dependencies.sh
@@ -60,4 +60,4 @@ fi
 
 # Ensure /usr/local/bin is in path
 export PATH=$PATH:/usr/local/bin:/usr/local/go/bin
-export GOPATH=$HOME/gopath
+export GOPATH=$HOME/gopath 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it**:
This PR fixes the Apt command not found error of install_dependencies script in centos9 for Delfin installation

**Which issue(s) this PR fixes**:
Fixes #527 

**Test Report Added?**:
/kind TESTED

**Test Report**:

![Capture](https://user-images.githubusercontent.com/122307186/231688139-9a4ed765-d53e-4e44-aa76-86473e615b6b.PNG)

**Special notes for your reviewer**:
