### PR TITLE
hotpot60

### DIFF
--- a/main43.yml
+++ b/main43.yml
@@ -1,0 +1,29 @@
+# Copyright 2021 The SODA Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Reload daemon
+  systemd: daemon_reload=yes
+
+- name: start Controller service
+  systemd:
+    name: osdslet
+    state: started
+    enabled: yes
+
+- name:start API service
+  systemd:
+    name: osdsapiserver
+    state: started
+    enabled: yes


### PR DESCRIPTION
i)issues/feature description:
installation failed while using hotpot, while logging in a blank screen appears with no login option. ii)why this issue need to be fixed/feature needed: unable to login as no login options appears
ii)how to reproduce in case of bug:
N/A
iv)other notes/environment information
used environment ubuntu version 22.0 supported environment: Ubuntu 18 & 20 @vpriyapm
